### PR TITLE
Migrate to Wasp 0.13.0

### DIFF
--- a/app/main.wasp
+++ b/app/main.wasp
@@ -1,6 +1,6 @@
 app OpenSaaS {
   wasp: {
-    version: "^0.12.0"
+    version: "^0.13.0"
   },
   title: "My Open SaaS App",
   head: [

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -56,7 +56,6 @@
         "axios": "^1.4.0",
         "express": "~4.18.1",
         "jsdom": "^21.1.1",
-        "jsonwebtoken": "^8.5.1",
         "lodash.merge": "^4.6.2",
         "lucia": "^3.0.1",
         "mitt": "3.0.0",
@@ -7653,51 +7652,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
-    "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/jwa": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -7765,45 +7719,15 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9607,14 +9531,6 @@
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/send": {

--- a/app/src/server/auth/setUsername.ts
+++ b/app/src/server/auth/setUsername.ts
@@ -15,32 +15,26 @@ export const getEmailUserFields = defineUserSignupFields({
 export const getGitHubUserFields = defineUserSignupFields({
   // NOTE: if we don't want to access users' emails, we can use scope ["user:read"]
   // instead of ["user"] and access args.profile.username instead
-  email: (data: any) => data.profile.emails[0].value,
-  username: (data: any) => data.profile.username,
-  isAdmin: (data: any) => adminEmails.includes(data.profile.emails[0].value),
+  email: (data: any) => data.profile.emails[0].email,
+  username: (data: any) => data.profile.login,
+  isAdmin: (data: any) => adminEmails.includes(data.profile.emails[0].email),
 });
 
 export function getGitHubAuthConfig() {
   return {
-    clientID: process.env.GITHUB_CLIENT_ID, // look up from env or elsewhere
-    clientSecret: process.env.GITHUB_CLIENT_SECRET, // look up from env or elsewhere
-    scope: ['user'],
+    scopes: ['user'],
   };
 }
 
 export const getGoogleUserFields = defineUserSignupFields({
-  email: (data: any) => data.profile.emails[0].value,
-  username: (data: any) => data.profile.displayName,
-  isAdmin: (data: any) => adminEmails.includes(data.profile.emails[0].value),
+  email: (data: any) => data.profile.email,
+  username: (data: any) => data.profile.name,
+  isAdmin: (data: any) => adminEmails.includes(data.profile.email),
 });
 
 export function getGoogleAuthConfig() {
-  const clientID = process.env.GOOGLE_CLIENT_ID;
-  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
   return {
-    clientID, // look up from env or elsewhere,
-    clientSecret, // look up from env or elsewhere,
-    scope: ['profile', 'email'], // must include at least 'profile' for Google
+    scopes: ['profile', 'email'], // must include at least 'profile' for Google
   };
 }
 


### PR DESCRIPTION
Follows the migrating guide from the unpublished docs for Wasp 0.13.0 https://wasp-0-13-0-docs.surge.sh/docs/migrate-from-0-12-to-0-13

@vincanger some things left to do for you:
- [ ] Update the `deployed-version` branch to match
- [ ] Update the docs to match (mentioned 0.13.0 instead of 0.12.0, link to newest migration docs, what ever you feel like is the best, really)
- [ ] Add a `WASP_SERVER_URL` env var in the deployed server app (just add the server URL)
- [ ] Update the redirect URL for the OAuth providers (`{clientUrl}/auth/login/{provider}` -> `{serverUrl}/auth/{provider}/callback`, you can see that in the docs I linked above)