### PR TITLE
Removed top level .prettierrc.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-}


### PR DESCRIPTION
While looking at top-level .gitignore, I realized there is also a top-level .prettierrc.
Is this one also a leftover? It seemed a bit alone there, out of context. We could leave it in theory, but since there is one already in `app/`, maybe best if we remove this one?