### PR TITLE
add instructions for local e2e env vars

### DIFF
--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -22,12 +22,6 @@ GOOGLE_CLIENT_SECRET=GOC...
 # get your sendgrid api key at https://app.sendgrid.com/settings/api_keys
 SENDGRID_API_KEY=test...
 
-# NOTE: Set this to "true" before running e2e tests locally!
-# When using the email auth method a verification link is sent, or logged to the console if you're using 
-# the default Dummy provider, when the user registers. You must click this link to complete registration.
-# Setting this to "true" skips this verification step, allowing you to automatically log in.
-SKIP_EMAIL_VERIFICATION_IN_DEV=false
-
 # (OPTIONAL) get your openai api key at https://platform.openai.com/account
 OPENAI_API_KEY=sk-k...
 

--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -22,6 +22,12 @@ GOOGLE_CLIENT_SECRET=GOC...
 # get your sendgrid api key at https://app.sendgrid.com/settings/api_keys
 SENDGRID_API_KEY=test...
 
+# NOTE: Set this to "true" before running e2e tests locally!
+# When using the email auth method a verification link is sent, or logged to the console if you're using 
+# the default Dummy provider, when the user registers. You must click this link to complete registration.
+# Setting this to "true" skips this verification step, allowing you to automatically log in.
+SKIP_EMAIL_VERIFICATION_IN_DEV=false
+
 # (OPTIONAL) get your openai api key at https://platform.openai.com/account
 OPENAI_API_KEY=sk-k...
 

--- a/template/e2e-tests/README.md
+++ b/template/e2e-tests/README.md
@@ -23,10 +23,12 @@ Start your Wasp DB and leave it running:
 cd ../app && wasp db start
 ```
 
-Open another terminal and start the Wasp app:
+Open another terminal and start the Wasp app with the environment variable set to skip email verification in development mode:
 ```shell
-cd app && wasp start
+cd app && SKIP_EMAIL_VERIFICATION_IN_DEV=true wasp start
 ```
+
+NOTE: When using the email auth method a verification link is sent when the user registers, or logged to the console if you're using the default Dummy provider. You must click this link to complete registration. Setting SKIP_EMAIL_VERIFICATION_IN_DEV to "true" skips this verification step, allowing you to automatically log in. This step must be skipped when running tests, otherwise the tests will hang and fail as the verification link is never clicked!
 
 In another terminal, run the local e2e tests:
 ```shell

--- a/template/e2e-tests/README.md
+++ b/template/e2e-tests/README.md
@@ -8,11 +8,6 @@ They not only serve as tests for development of the Open SaaS project, but also 
 ### Locally
 First, make sure you've [integrated Stripe into your app](https://docs.opensaas.sh/guides/stripe-integration/). This includes  [installing the Stripe CLI and logging into it](https://docs.opensaas.sh/guides/stripe-testing/) with your Stripe account.
 
-Then, in `.env.server`, make sure to skip the email verification step on signup, so that we can automatically log in the test user:
-```shell
-SKIP_EMAIL_VERIFICATION_IN_DEV=true
-```
-
 Next, Install the test dependencies:
 ```shell
 cd e2e-tests && npm install

--- a/template/e2e-tests/README.md
+++ b/template/e2e-tests/README.md
@@ -8,6 +8,11 @@ They not only serve as tests for development of the Open SaaS project, but also 
 ### Locally
 First, make sure you've [integrated Stripe into your app](https://docs.opensaas.sh/guides/stripe-integration/). This includes  [installing the Stripe CLI and logging into it](https://docs.opensaas.sh/guides/stripe-testing/) with your Stripe account.
 
+Then, in `.env.server`, make sure to skip the email verification step on signup, so that we can automatically log in the test user:
+```shell
+SKIP_EMAIL_VERIFICATION_IN_DEV=true
+```
+
 Next, Install the test dependencies:
 ```shell
 cd e2e-tests && npm install


### PR DESCRIPTION
instructed users to add `SKIP_EMAIL_VERIFICATION_IN_DEV=true` to `.env.server` before running local e2e tests to automatically verify the test user on signup
