### PR TITLE
Make the user entitiy use a uuid as its identifier

### DIFF
--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -118,7 +118,7 @@ entity GptResponse {=psl
   updatedAt                 DateTime        @updatedAt
 
   user                      User            @relation(fields: [userId], references: [id])
-  userId                    Int
+  userId                    String
 
   content                   String
 psl=}
@@ -128,7 +128,7 @@ entity Task {=psl
   createdAt                 DateTime        @default(now())
 
   user                      User            @relation(fields: [userId], references: [id])
-  userId                    Int
+  userId                    String
 
   description               String
   time                      String          @default("1")
@@ -140,7 +140,7 @@ entity File {=psl
   createdAt                 DateTime        @default(now())
 
   user                      User            @relation(fields: [userId], references: [id])
-  userId                    Int
+  userId                    String
 
   name                      String
   type                      String
@@ -155,7 +155,7 @@ entity ContactFormMessage {=psl
   createdAt                 DateTime        @default(now())
 
   user                      User            @relation(fields: [userId], references: [id])
-  userId                    Int
+  userId                    String
 
   content                   String
   isRead                    Boolean         @default(false)

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -90,7 +90,7 @@ app OpenSaaS {
  */
 
 entity User {=psl
-  id                        Int             @id @default(autoincrement())
+  id                        String          @id @default(uuid())
   createdAt                 DateTime        @default(now())
 
   email                     String?         @unique

--- a/template/app/src/server/actions.ts
+++ b/template/app/src/server/actions.ts
@@ -286,7 +286,7 @@ export const deleteTask: DeleteTask<Pick<Task, 'id'>, Task> = async ({ id }, con
   return task;
 };
 
-export const updateUserById: UpdateUserById<{ id: number; data: Partial<User> }, User> = async (
+export const updateUserById: UpdateUserById<{ id: string; data: Partial<User> }, User> = async (
   { id, data },
   context
 ) => {
@@ -318,7 +318,7 @@ export const createFile: CreateFile<fileArgs, File> = async ({ fileType, name },
     throw new HttpError(401);
   }
 
-  const userInfo = context.user.id.toString();
+  const userInfo = context.user.id;
 
   const { uploadUrl, key } = await getUploadFileSignedURLFromS3({ fileType, userInfo });
 


### PR DESCRIPTION
## Description

As discussed on Discord, change the default User entity ID to use a uuid instead of an int.

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
