### PR TITLE
Add note on `sudo` for Stripe CLI 

### DIFF
--- a/opensaas-sh/blog/src/content/docs/guides/stripe-integration.md
+++ b/opensaas-sh/blog/src/content/docs/guides/stripe-integration.md
@@ -95,6 +95,21 @@ or for other install scripts or OSes, follow the instructions [here](https://str
 
 Now, let's start the webhook server and get our webhook signing secret.
 
+First, login:
+```sh
+stripe login
+```
+
+:::caution[Errors running the Stripe CLI]
+If you're seeing errors, try appending `sudo` to the stripe commands:
+```sh
+sudo stripe login
+sudo stripe listen --forward-to localhost:3001/stripe-webhook
+```
+
+See this [GitHuh issue](https://github.com/stripe/stripe-cli/issues/933) for more details.
+:::
+
 ```sh
 stripe listen --forward-to localhost:3001/stripe-webhook
 ```

--- a/opensaas-sh/blog/src/content/docs/guides/stripe-integration.md
+++ b/opensaas-sh/blog/src/content/docs/guides/stripe-integration.md
@@ -101,12 +101,7 @@ stripe login
 ```
 
 :::caution[Errors running the Stripe CLI]
-If you're seeing errors, try appending `sudo` to the stripe commands:
-```sh
-sudo stripe login
-sudo stripe listen --forward-to localhost:3001/stripe-webhook
-```
-
+If you're seeing errors, consider appending `sudo` to the stripe commands.
 See this [GitHuh issue](https://github.com/stripe/stripe-cli/issues/933) for more details.
 :::
 


### PR DESCRIPTION
A user on WSL encountered errors running the Stripe CLI: https://discord.com/channels/686873244791210014/1253545019785351180/1253951893877817527

The workaround was to append `sudo` to the commands as referenced in the GitHub issue (provided in the docs)