### PR TITLE
Updated edit page link to point to new repo structure.

### DIFF
--- a/opensaas-sh/blog/astro.config.mjs
+++ b/opensaas-sh/blog/astro.config.mjs
@@ -36,7 +36,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: 'https://github.com/wasp-lang/open-saas/edit/deployed-version/blog',
+        baseUrl: 'https://github.com/wasp-lang/open-saas/edit/main/opensaas-sh/blog',
       },
       components: {
         SiteTitle: './src/components/MyHeader.astro',


### PR DESCRIPTION
Motivated by https://github.com/wasp-lang/open-saas/pull/204 -> @vincanger , what should we do with the edit page link? It shouldn't point to dpeloyed-version anymore -> so it can either point to `main`, which is good because users edit the latest version, but also a bit confusing because it might be different then what is deployed, or, we have it point to the latest released version, which we would probably have to do by refereing it via git tag (e.g. `template-version-0.13`, which we need to then keep updating in astro.config.js and are likely to forget.

I would maybe just have it point to `main` for the sake of simplicity for now, and once we have a bit more sophisticated way of tracking what is released (e.g. a `release` branch) then we can do something better. If so, this PR is it.