### PR TITLE
Update stripe webhook comment documentation to show where to find default stripe api version

### DIFF
--- a/template/app/src/server/webhooks/stripe.ts
+++ b/template/app/src/server/webhooks/stripe.ts
@@ -8,7 +8,7 @@ import Stripe from 'stripe';
 
 // make sure the api version matches the version in the Stripe dashboard
 const stripe = new Stripe(process.env.STRIPE_KEY!, {
-  apiVersion: '2022-11-15', // TODO find out where this is in the Stripe dashboard and document
+  apiVersion: '2022-11-15', // Find your version here - https://docs.stripe.com/development/dashboard/request-logs#view-your-default-api-version
 });
 
 export const stripeWebhook: StripeWebhook = async (request, response, context) => {


### PR DESCRIPTION
## Description

Updated stripe webhook comment documentation to show where to find default stripe api version. This implements a TODO comment that existed there.
