### PR TITLE
add instructions about switching proivders in Job to google analytics

### DIFF
--- a/opensaas-sh/blog/src/content/docs/general/admin-dashboard.md
+++ b/opensaas-sh/blog/src/content/docs/general/admin-dashboard.md
@@ -79,6 +79,7 @@ job dailyStatsJob {
   entities: [User, DailyStats, Logs, PageViewSource]
 }
 ```
+For more info on Wasp's recurring background jobs, check out the [Wasp Jobs docs](https://wasp-lang.dev/docs/advanced/jobs).
 
 For a guide on how to integrate these services so that you can view your analytics via the dashboard, check out the [Stripe](/guides/stripe-integration) and [Analytics guide](/guides/analytics) of the docs.
 

--- a/opensaas-sh/blog/src/content/docs/guides/analytics.md
+++ b/opensaas-sh/blog/src/content/docs/guides/analytics.md
@@ -58,9 +58,21 @@ As a completely free, open-source project, we appreciate any help 🙏
 
 ## Google Analytics
 
-After you sign up for [Google analytics](https://analytics.google.com/), go to your `Admin` panel in the bottom of the left sidebar and then create a "Property" for your app.
+First off, head over to `src/analytics/stats.ts` and switch out the Plausible Provider for Google Analytics so that your [background (cron) job](https://wasp-lang.dev/docs/advanced/jobs) fetches the data from Google Analytics for your [Admin Dashboard](/general/admin-dashboard/):
 
-Once you've completed the steps to create a new Property, some Installation Instructions will pop up. Select `install manually` where you should see a string that looks like this:
+```ts ins={3} del={2} title="stats.ts"
+//...
+import { getDailyPageViews, getSources } from './providers/plausibleAnalyticsUtils';
+import { getDailyPageViews, getSources } from './providers/googleAnalyticsUtils';
+
+export const calculateDailyStats: DailyStatsJob<never, void> = async (_args, context) => { 
+  //...
+}
+```
+
+Next, make sure you sign up for [Google analytics](https://analytics.google.com/), then go to your `Admin` panel in the bottom of the left sidebar and then create a "Property" for your app.
+
+Once you've created a new Property, some Installation Instructions will pop up. Select `install manually` where you should see a string that looks like this:
 
 ```sh title="<your-google-analytics-id>"
  https://www.googletagmanager.com/gtag/js?id=<your-google-analytics-id>


### PR DESCRIPTION
in reference to this [discord convo](https://discord.com/channels/686873244791210014/1265391904472825966/1265721824596066335):

- updates the docs to let users know to switch to the google analytics provider utility functions within the `dailyStatsJob` if they want to use GA instead of Plausible. 
- adds more info about Wasp Jobs to docs
