### PR TITLE
Use a version range for Zod dep

### DIFF
--- a/template/app/package.json
+++ b/template/app/package.json
@@ -12,7 +12,7 @@
     "clsx": "^2.1.0",
     "headlessui": "^0.0.0",
     "node-fetch": "3.3.0",
-    "openai": "^4.52.1",
+    "openai": "^4.55.3",
     "prettier": "3.1.1",
     "prettier-plugin-tailwindcss": "0.5.11",
     "react": "^18.2.0",
@@ -23,7 +23,7 @@
     "tailwind-merge": "^2.2.1",
     "vanilla-cookieconsent": "^3.0.1",
     "wasp": "file:.wasp/out/sdk/wasp",
-    "zod": "3.22.4"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",


### PR DESCRIPTION
### OpenAI SDK and Zod dep issue

Users reported:
```
[  Wasp !] npm error code ERESOLVE
[  Wasp !] npm error ERESOLVE could not resolve
[  Wasp !] npm error
[  Wasp !] npm error While resolving: openai@4.55.1
[  Wasp !] npm error Found: zod@3.22.4
[  Wasp !] npm error node_modules/zod
[  Wasp !] npm error   zod@"3.22.4" from the root project
[  Wasp !] npm error
[  Wasp !] npm error Could not resolve dependency:
[  Wasp !] npm error peerOptional zod@"^3.23.8" from openai@4.55.1
[  Wasp !] npm error node_modules/openai
[  Wasp !] npm error   openai@"^4.52.1" from the root project
[  Wasp !] npm error
[  Wasp !] npm error Conflicting peer dependency: zod@3.23.8
[  Wasp !] npm error node_modules/zod
[  Wasp !] npm error   peerOptional zod@"^3.23.8" from openai@4.55.1
[  Wasp !] npm error   node_modules/openai
[  Wasp !] npm error     openai@"^4.52.1" from the root project
[  Wasp !] npm error
[  Wasp !] npm error Fix the upstream dependency conflict, or retry
[  Wasp !] npm error this command with --force or --legacy-peer-deps
[  Wasp !] npm error to accept an incorrect (and potentially broken) dependency resolution.
```

### What went wrong

We used a single version for Zod i.e. `3.22.4` and when the Open AI SDK started requiring a certain version of Zod, our single version couldn't satisfy it.

### How we fixed it

Instead of using a single version, I've now updated the Zod dep to use a version range with a caret (the `^` symbol) which says: it's okay to use any `3.X.X` version of Zod. 

```diff
- "zod": "3.22.4"
+ "zod": "^3.23.8"
```

### Testing

✅  I've ran the template locally
✅  I've deployed the new version to opensaas.sh