### PR TITLE
improve logic for no lemon squeezy customer portal url

### DIFF
--- a/template/app/src/payment/lemonSqueezy/paymentProcessor.ts
+++ b/template/app/src/payment/lemonSqueezy/paymentProcessor.ts
@@ -29,11 +29,9 @@ export const lemonSqueezyPaymentProcessor: PaymentProcessor = {
         lemonSqueezyCustomerPortalUrl: true,
       },
     });
-    if (!user.lemonSqueezyCustomerPortalUrl) {
-      console.log(`User with ID ${args.userId} does not have a LemonSqueezy customer portal URL`);
-    } else {
-      return user.lemonSqueezyCustomerPortalUrl;
-    }
+    // Note that Lemon Squeezy assigns a unique URL to each user after the first successful payment.
+    // This is handled in the Lemon Squeezy webhook.
+    return user.lemonSqueezyCustomerPortalUrl;
   },
   webhook: lemonSqueezyWebhook,
   webhookMiddlewareConfigFn: lemonSqueezyMiddlewareConfigFn,

--- a/template/app/src/payment/operations.ts
+++ b/template/app/src/payment/operations.ts
@@ -1,5 +1,4 @@
 import type { GenerateCheckoutSession, GetCustomerPortalUrl } from 'wasp/server/operations';
-import type { FetchCustomerPortalUrlArgs } from './paymentProcessor';
 import { PaymentPlanId, paymentPlans } from '../payment/plans';
 import { paymentProcessor } from './paymentProcessor';
 import { HttpError } from 'wasp/server';
@@ -39,7 +38,7 @@ export const generateCheckoutSession: GenerateCheckoutSession<PaymentPlanId, Che
   };
 };
 
-export const getCustomerPortalUrl: GetCustomerPortalUrl<void, string | undefined> = async (_args, context) => {
+export const getCustomerPortalUrl: GetCustomerPortalUrl<void, string | null> = async (_args, context) => {
   if (!context.user) {
     throw new HttpError(401);
   }

--- a/template/app/src/payment/paymentProcessor.ts
+++ b/template/app/src/payment/paymentProcessor.ts
@@ -19,7 +19,7 @@ export interface FetchCustomerPortalUrlArgs {
 export interface PaymentProcessor {
   id: 'stripe' | 'lemonsqueezy';
   createCheckoutSession: (args: CreateCheckoutSessionArgs) => Promise<{ session: { id: string; url: string }; }>; 
-  fetchCustomerPortalUrl: (args: FetchCustomerPortalUrlArgs) => Promise<string | undefined>;
+  fetchCustomerPortalUrl: (args: FetchCustomerPortalUrlArgs) => Promise<string | null>;
   webhook: PaymentsWebhook;
   webhookMiddlewareConfigFn: MiddlewareConfigFn;
 }

--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -124,6 +124,8 @@ function CustomerPortalButton() {
 
     if (customerPortalUrl) {
       window.open(customerPortalUrl, '_blank');
+    } else {
+      console.error('Customer portal URL is not available');
     }
   };
 


### PR DESCRIPTION
we had a user confused by the current console.log statement `User with ID 123... does not have a LemonSqueezy customer portal URL` so I removed the log and added a note to the file. I also changed a bit of the logic.