### PR TITLE
Update mailgun links for api keys and domains

### DIFF
--- a/opensaas-sh/blog/src/content/docs/guides/email-sending.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/email-sending.mdx
@@ -86,9 +86,9 @@ To set up your email sender, you first need an account with one of the supported
   </TabItem>
   <TabItem label="Mailgun">
     - Go to [Mailgun](https://mailgun.com) and create an account.
-    - Go to [API Keys](https://app.mailgun.com/app/account/security/api_keys) and create a new API key.
+    - Go to [API Keys](https://app.mailgun.com/settings/api_security/api_keys?onboardingTask=api-key) and create a new API key.
     - Copy the API key and add it to your .env.server file under the `MAILGUN_API_KEY=` variable.
-    - Go to [Domains](https://app.mailgun.com/app/domains) and create a new domain.
+    - Go to [Domains](https://app.mailgun.com/mg/sending/new-domain?onboardingTask=add-verify-domain) and create a new domain.
     - Copy the domain and add it to your .env.server file as `MAILGUN_DOMAIN=`.
 
     Make sure to change the `defaultFrom` email address in the `main.wasp` file to use the same email address that you configured your account to send out emails with!


### PR DESCRIPTION
## Description

> Describe your PR! If it fixes specific issue, mention it with "Fixes # (issue)".

Old links for API Key and Domains have changed:

- Current Api key link leads to a 404
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/7ae64569-a2e1-404b-b886-9dd804103cb0">


- Domain leads to a blank page
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/7748b1cf-4f84-4d05-965e-67195f0f2a8f">

New links lead to the right pages:

- New API key link

<img width="1400" alt="image" src="https://github.com/user-attachments/assets/9eabec2e-ad3d-4158-886d-344204252226">

- New domain link

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/28014c00-9d91-4a20-9c5f-859e438ce644">



## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
