### PR TITLE
Most Annoying Cookie Banner Submission: Glubker

### DIFF
--- a/MOST-ANNOYING-COOKIE-BANNER.md
+++ b/MOST-ANNOYING-COOKIE-BANNER.md
@@ -1,1 +1,1 @@
-your-github-username: your-stackblitz-embed-url
+Glubker: https://stackblitz.com/edit/github-gcme21?embed=1&file=src%2Flanding-page%2Fcomponents%2FHero.tsx&view=preview

--- a/MOST-ANNOYING-COOKIE-BANNER.md
+++ b/MOST-ANNOYING-COOKIE-BANNER.md
@@ -1,1 +1,11 @@
-Glubker: https://stackblitz.com/edit/github-gcme21?embed=1&file=src%2Flanding-page%2Fcomponents%2FHero.tsx&view=preview
+Most Annoying Cookie Banner Submission: Glubker
+
+Github Username: Glubker
+
+**I recommend using this link instead as it seems to be more stable and faster than through StackBlitz:
+[https://annoying-cookie-banner.vercel.app/](https://annoying-cookie-banner.vercel.app/)   (RECOMMENDED)**
+
+
+
+Otherwise, the Stackblitz link is available here along with the code:
+https://stackblitz.com/edit/github-gcme21?embed=1&file=src%2Flanding-page%2Fcomponents%2FHero.tsx&view=preview


### PR DESCRIPTION
Most Annoying Cookie Banner Submission: Glubker

Github Username: Glubker

**I recommend using this link instead as it seems to be more stable and faster than through StackBlitz:
[https://annoying-cookie-banner.vercel.app/](https://annoying-cookie-banner.vercel.app/)   (RECOMMENDED)**

––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––

Otherwise if needed, the StackBlitz url is below along with the source code, but it is recommended to use the Vercel link instead.
https://stackblitz.com/edit/github-gcme21?embed=1&file=src%2Flanding-page%2Fcomponents%2FHero.tsx&view=preview