### PR TITLE
Add proxied Plausible analytics

### DIFF
--- a/opensaas-sh/app_diff/main.wasp.diff
+++ b/opensaas-sh/app_diff/main.wasp.diff
@@ -1,6 +1,6 @@
 --- template/app/main.wasp
 +++ opensaas-sh/app/main.wasp
-@@ -3,30 +3,30 @@
+@@ -3,30 +3,29 @@
      version: "^0.15.0"
    },
  
@@ -43,12 +43,12 @@
 -    // via the Cookie Consent component after the user clicks the "Accept" cookies button.
 -    "<script defer data-domain='<your-site-id>' src='https://plausible.io/js/script.js'></script>",  // for production
 -    "<script defer data-domain='<your-site-id>' src='https://plausible.io/js/script.local.js'></script>",  // for development
-+    "<script defer data-domain='opensaas.sh' src='https://plausible.apps.twoducks.dev/js/script.js'></script>",
-+    "<script defer data-domain='opensaas.sh' src='https://plausible.apps.twoducks.dev/js/script.local.js'></script>",
++    "<script defer data-domain='opensaas.sh' data-api='/waspara/wasp/event' src='/waspara/wasp/script.js'></script>",
    ],
  
    // 🔐 Auth out of the box! https://wasp-lang.dev/docs/auth/overview
-@@ -38,7 +38,7 @@
+\ No newline at end of file
+@@ -38,7 +37,7 @@
        email: {
          fromField: {
            name: "Open SaaS App",
@@ -57,7 +57,8 @@
          },
          emailVerification: {
            clientRoute: EmailVerificationRoute,
-@@ -50,21 +50,18 @@
+\ No newline at end of file
+@@ -50,21 +49,18 @@
          },
          userSignupFields: import { getEmailUserFields } from "@src/auth/userSignupFields",
        },
@@ -91,7 +92,8 @@
      },
      onAfterSignup: import { onAfterSignup } from "@src/auth/hooks",
      onAuthFailedRedirectTo: "/login",
-@@ -87,11 +84,11 @@
+\ No newline at end of file
+@@ -87,11 +83,11 @@
      // NOTE: "Dummy" provider is just for local development purposes.
      //   Make sure to check the server logs for the email confirmation url (it will not be sent to an address)!
      //   Once you are ready for production, switch to e.g. "SendGrid" or "Mailgun" providers. Check out https://docs.opensaas.sh/guides/email-sending/ .
@@ -105,7 +107,8 @@
      },
    },
  }
-@@ -212,9 +209,9 @@
+\ No newline at end of file
+@@ -212,9 +208,9 @@
  }
  
  api paymentsWebhook {
@@ -117,3 +120,4 @@
    httpRoute: (POST, "/payments-webhook")
  }
  //#endregion
+\ No newline at end of file

--- a/opensaas-sh/app_diff/src/landing-page/components/Header.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Header.tsx.diff
@@ -24,7 +24,7 @@
 +            className='flex items-center -m-1.5 p-1.5 text-gray-900 duration-300 ease-in-out hover:text-yellow-500 dark:text-white'
            >
              <NavLogo />
--            <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your Saas</span>
+-            <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your SaaS</span>
 +            <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Open SaaS</span>
            </a>
          </div>


### PR DESCRIPTION
- This is a draft PR until we setup Plausible on plauisble.io
- It uses the proxied URL via Cloudflare Workers
- I deleted the `.local.js` second script since `local` is used if you want to track events on `localhost` - which we probably don't want
- I resolved a conflict in the `Header` component so I got this diff
