### PR TITLE
change url to wasp.sh, fixes `updateCurrentUser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This template is:
 
 The template itself is built on top of some very powerful tools and frameworks, including:
 
-- 🐝 [Wasp](https://wasp-lang.dev) - a full-stack React, NodeJS, Prisma framework with superpowers
+- 🐝 [Wasp](https://wasp.sh) - a full-stack React, NodeJS, Prisma framework with superpowers
 - 🚀 [Astro](https://starlight.astro.build/) - Astro's lightweight "Starlight" template for documentation and blog
 - 💸 [Stripe](https://stripe.com) or [Lemon Squeezy](https://lemonsqueezy.com/) - for products and payments
 - 📈 [Plausible](https://plausible.io) or [Google](https://analytics.google.com/) Analytics
@@ -32,10 +32,10 @@ The template itself is built on top of some very powerful tools and frameworks, 
 
 Because we're using Wasp as the full-stack framework, we can leverage a lot of its features to build our SaaS in record time, including:
 
-- 🔐 [Full-stack Authentication](https://wasp-lang.dev/docs/auth/overview) - Email verified + social Auth in a few lines of code.
-- ⛑ [End-to-end Type Safety](https://wasp-lang.dev/docs/data-model/operations/overview) - Type your backend functions and get inferred types on the front-end automatically, without the need to install or configure any third-party libraries. Oh, and type-safe Links, too!
-- 🤖 [Jobs](https://wasp-lang.dev/docs/advanced/jobs) - Run cron jobs in the background or set up queues simply by defining a function in the config file.
-- 🚀 [One-command Deploy](https://wasp-lang.dev/docs/advanced/deployment/overview) - Easily deploy via the CLI to [Fly.io](https://fly.io), or to other providers like [Railway](https://railway.app) and [Netlify](https://netlify.com).
+- 🔐 [Full-stack Authentication](https://wasp.sh/docs/auth/overview) - Email verified + social Auth in a few lines of code.
+- ⛑ [End-to-end Type Safety](https://wasp.sh/docs/data-model/operations/overview) - Type your backend functions and get inferred types on the front-end automatically, without the need to install or configure any third-party libraries. Oh, and type-safe Links, too!
+- 🤖 [Jobs](https://wasp.sh/docs/advanced/jobs) - Run cron jobs in the background or set up queues simply by defining a function in the config file.
+- 🚀 [One-command Deploy](https://wasp.sh/docs/advanced/deployment/overview) - Easily deploy via the CLI to [Fly.io](https://fly.io), or to other providers like [Railway](https://railway.app) and [Netlify](https://netlify.com).
 
 You also get access to Wasp's diverse, helpful community if you get stuck or need help.
 - 🤝 [Wasp Discord](https://discord.gg/aCamt5wCpS)

--- a/opensaas-sh/app_diff/README.md.diff
+++ b/opensaas-sh/app_diff/README.md.diff
@@ -4,7 +4,7 @@
 -# <YOUR_APP_NAME>
 +# opensaas.sh (demo) app
  
--Built with [Wasp](https://wasp-lang.dev), based on the [Open Saas](https://opensaas.sh) template.
+-Built with [Wasp](https://wasp.sh), based on the [Open Saas](https://opensaas.sh) template.
 +This is a Wasp app based on Open Saas template with minimal modifications that make it into a demo app that showcases Open Saas's abilities.
 +
 +It is deployed to https://opensaas.sh and serves both as a landing page for Open Saas and as a demo app.

--- a/opensaas-sh/app_diff/main.wasp.diff
+++ b/opensaas-sh/app_diff/main.wasp.diff
@@ -46,7 +46,7 @@
 +    "<script defer data-domain='opensaas.sh' data-api='/waspara/wasp/event' src='/waspara/wasp/script.js'></script>",
    ],
  
-   // 🔐 Auth out of the box! https://wasp-lang.dev/docs/auth/overview
+   // 🔐 Auth out of the box! https://wasp.sh/docs/auth/overview
 @@ -38,7 +37,7 @@
        email: {
          fromField: {
@@ -60,17 +60,17 @@
          },
          userSignupFields: import { getEmailUserFields } from "@src/auth/userSignupFields",
        },
--      // Uncomment to enable Google Auth (check https://wasp-lang.dev/docs/auth/social-auth/google for setup instructions):
+-      // Uncomment to enable Google Auth (check https://wasp.sh/docs/auth/social-auth/google for setup instructions):
 -      // google: { // Guide for setting up Auth via Google
 -      //   userSignupFields: import { getGoogleUserFields } from "@src/auth/userSignupFields",
 -      //   configFn: import { getGoogleAuthConfig } from "@src/auth/userSignupFields",
 -      // },
--      // Uncomment to enable GitHub Auth (check https://wasp-lang.dev/docs/auth/social-auth/github for setup instructions):
+-      // Uncomment to enable GitHub Auth (check https://wasp.sh/docs/auth/social-auth/github for setup instructions):
 -      // gitHub: {
 -      //   userSignupFields: import { getGitHubUserFields } from "@src/auth/userSignupFields",
 -      //   configFn: import { getGitHubAuthConfig } from "@src/auth/userSignupFields",
 -      // },
--      // Uncomment to enable Discord Auth (check https://wasp-lang.dev/docs/auth/social-auth/discord for setup instructions):
+-      // Uncomment to enable Discord Auth (check https://wasp.sh/docs/auth/social-auth/discord for setup instructions):
 -      // discord: {
 -      //   userSignupFields: import { getDiscordUserFields } from "@src/auth/userSignupFields",
 -      //   configFn: import { getDiscordAuthConfig } from "@src/auth/userSignupFields"

--- a/opensaas-sh/app_diff/src/user/operations.ts.diff
+++ b/opensaas-sh/app_diff/src/user/operations.ts.diff
@@ -1,6 +1,6 @@
 --- template/app/src/user/operations.ts
 +++ opensaas-sh/app/src/user/operations.ts
-@@ -50,7 +50,10 @@
+@@ -52,7 +52,10 @@
    subscriptionStatus?: SubscriptionStatus[];
  };
  type GetPaginatedUsersOutput = {
@@ -12,7 +12,7 @@
    totalPages: number;
  };
  
-@@ -63,8 +66,10 @@
+@@ -65,8 +68,10 @@
    }
  
    const allSubscriptionStatusOptions = args.subscriptionStatus as Array<string | null> | undefined;
@@ -25,7 +25,7 @@
  
    const queryResults = await context.entities.User.findMany({
      skip: args.skip,
-@@ -77,6 +82,7 @@
+@@ -79,6 +84,7 @@
              mode: 'insensitive',
            },
            isAdmin: args.isAdmin,
@@ -33,7 +33,7 @@
          },
          {
            OR: [
-@@ -101,7 +107,7 @@
+@@ -103,7 +109,7 @@
        isAdmin: true,
        lastActiveTimestamp: true,
        subscriptionStatus: true,
@@ -42,7 +42,7 @@
      },
      orderBy: {
        id: 'desc',
-@@ -117,6 +123,7 @@
+@@ -119,6 +125,7 @@
              mode: 'insensitive',
            },
            isAdmin: args.isAdmin,

--- a/opensaas-sh/app_diff/src/user/operations.ts.diff
+++ b/opensaas-sh/app_diff/src/user/operations.ts.diff
@@ -1,16 +1,6 @@
 --- template/app/src/user/operations.ts
 +++ opensaas-sh/app/src/user/operations.ts
-@@ -1,8 +1,4 @@
--import {
--  type UpdateCurrentUser,
--  type UpdateUserById,
--  type GetPaginatedUsers,
--} from 'wasp/server/operations';
-+import { type UpdateCurrentUser, type UpdateUserById, type GetPaginatedUsers } from 'wasp/server/operations';
- import { type User } from 'wasp/entities';
- import { HttpError } from 'wasp/server';
- import { type SubscriptionStatus } from '../payment/plans';
-@@ -50,7 +46,10 @@
+@@ -50,7 +50,10 @@
    subscriptionStatus?: SubscriptionStatus[];
  };
  type GetPaginatedUsersOutput = {
@@ -22,7 +12,7 @@
    totalPages: number;
  };
  
-@@ -63,8 +62,10 @@
+@@ -63,8 +66,10 @@
    }
  
    const allSubscriptionStatusOptions = args.subscriptionStatus as Array<string | null> | undefined;
@@ -35,7 +25,7 @@
  
    const queryResults = await context.entities.User.findMany({
      skip: args.skip,
-@@ -77,6 +78,7 @@
+@@ -77,6 +82,7 @@
              mode: 'insensitive',
            },
            isAdmin: args.isAdmin,
@@ -43,7 +33,7 @@
          },
          {
            OR: [
-@@ -101,7 +103,7 @@
+@@ -101,7 +107,7 @@
        isAdmin: true,
        lastActiveTimestamp: true,
        subscriptionStatus: true,
@@ -52,7 +42,7 @@
      },
      orderBy: {
        id: 'desc',
-@@ -117,6 +119,7 @@
+@@ -117,6 +123,7 @@
              mode: 'insensitive',
            },
            isAdmin: args.isAdmin,

--- a/opensaas-sh/blog/README.md
+++ b/opensaas-sh/blog/README.md
@@ -139,7 +139,7 @@ authors: {
     name: 'Vince',
     title: 'Dev Rel @ Wasp',
     picture: '/CRAIG_ROCK.png', // Put author images in the `public` directory.
-    url: 'https://wasp-lang.dev',
+    url: 'https://wasp.sh',
   },
 },
 ```

--- a/opensaas-sh/blog/astro.config.mjs
+++ b/opensaas-sh/blog/astro.config.mjs
@@ -85,19 +85,19 @@ export default defineConfig({
               name: 'Vince',
               title: 'Dev Rel @ Wasp',
               picture: '/CRAIG_ROCK.png', // Images in the `public` directory are supported.
-              url: 'https://wasp-lang.dev',
+              url: 'https://wasp.sh',
             },
             matija: {
               name: 'Matija',
               title: 'CEO @ Wasp',
               picture: '/matija.jpeg', // Images in the `public` directory are supported.
-              url: 'https://wasp-lang.dev',
+              url: 'https://wasp.sh',
             },
             milica: {
               name: 'Milica',
               title: 'Growth @ Wasp',
               picture: '/milica.jpg', // Images in the `public` directory are supported.
-              url: 'https://wasp-lang.dev',
+              url: 'https://wasp.sh',
             },
           },
         }),

--- a/opensaas-sh/blog/src/content/docs/blog/2023-11-21-coverlettergpt.mdx
+++ b/opensaas-sh/blog/src/content/docs/blog/2023-11-21-coverlettergpt.mdx
@@ -49,15 +49,15 @@ It also lets you save and manage your cover letters per each job, making it easy
 
 CoverLetterGPT is entirely open-source, so you can [check out the code](https://github.com/vincanger/coverlettergpt), fork it, learn from it, make your own, submit a PR (I’d love you forever if you did 🙂)… whatever!
 
-I built it using the [Wasp full-stack framework](https://wasp-lang.dev) which allowed me to ship it about 10x faster. 
+I built it using the [Wasp full-stack framework](https://wasp.sh) which allowed me to ship it about 10x faster. 
 
 Why? 
 
-Because [Wasp](https://wasp-lang.dev) as a framework allows you to describe your app’s core features in a `main.wasp` config file. Then it continually compiles and “glues” these features into a React-ExpressJS-Prisma full-stack app for you. 
+Because [Wasp](https://wasp.sh) as a framework allows you to describe your app’s core features in a `main.wasp` config file. Then it continually compiles and “glues” these features into a React-ExpressJS-Prisma full-stack app for you. 
 
 All you have to focus on is writing the client and server-side logic, and Wasp will do the boring stuff for you, like authentication & authorization, server config, email sending, and cron jobs. 
 
-BTW, [Wasp](https://wasp-lang.dev) is open-source and free and you can help the project out a ton by starring the repo on GitHub: [https://www.github.com/wasp-lang/wasp](https://www.github.com/wasp-lang/wasp) 🙏
+BTW, [Wasp](https://wasp.sh) is open-source and free and you can help the project out a ton by starring the repo on GitHub: [https://www.github.com/wasp-lang/wasp](https://www.github.com/wasp-lang/wasp) 🙏
 
 <Image src='https://media1.giphy.com/media/ZfK4cXKJTTay1Ava29/giphy.gif?cid=7941fdc6pmqo30ll0e4rzdiisbtagx97sx5t0znx4lk0auju&ep=v1_gifs_search&rid=giphy.gif&ct=g' loading="lazy" alt="star wasp" width={500} height={500} />
 

--- a/opensaas-sh/blog/src/content/docs/blog/2024-11-22-best-annoying-cookie-consent-banners.mdx
+++ b/opensaas-sh/blog/src/content/docs/blog/2024-11-22-best-annoying-cookie-consent-banners.mdx
@@ -20,7 +20,7 @@ import gangnamwinner from '@assets/cookie-banner-hackathon/285-3umaGH-gangnam.mp
 
 ## The Most Annoying Cookie Consent Banner Ever Hackathon
 
-We at [Wasp](https://wasp-lang.dev) just finished off a fun little [hackathon](https://docs.opensaas.sh/blog/2024-10-10-most-annoying-cookie-banner-contest/) where we asked our users to create the most annoying cookie consent banners they could think of (because cookie banners aren’t annoying enough already, right?). Then we let our community pick the winner in an elimination style tournament on [X/Twitter](https://x.com/wasplang).
+We at [Wasp](https://wasp.sh) just finished off a fun little [hackathon](https://docs.opensaas.sh/blog/2024-10-10-most-annoying-cookie-banner-contest/) where we asked our users to create the most annoying cookie consent banners they could think of (because cookie banners aren’t annoying enough already, right?). Then we let our community pick the winner in an elimination style tournament on [X/Twitter](https://x.com/wasplang).
 
 It was a lot of fun, and the submissions were really creative, so we thought we’d highlight some of our favorites for you, including the community chosen winner. Check ‘em out below. We hope they inspire you... to... not use them on your own sites. :)
 

--- a/opensaas-sh/blog/src/content/docs/blog/2024-12-10-turboreel-os-ai-video-generator-built-with-open-saas.mdx
+++ b/opensaas-sh/blog/src/content/docs/blog/2024-12-10-turboreel-os-ai-video-generator-built-with-open-saas.mdx
@@ -30,7 +30,7 @@ Peter's journey to Open SaaS began with a simple Google search for SaaS boilerpl
 
 *"I was looking for something that could save me time," Peter recalls. "I came across a few options—some were free but basic, and [others were paid but didn't feel worth it](https://docs.opensaas.sh/blog/2024-12-04-open-source-saas-boilerplate-vs-paid/). Then I found Wasp's Open SaaS boilerplate."*
 
-What stood out to Peter wasn't just that it was free, but that it was **open source**. *"I liked the idea of building on something maintained by a community, not locked behind a paywall"*, he says. Intrigued, Peter explored [Wasp](https://wasp-lang.dev/) further and discovered an engaging community that offered exactly what he needed to start building TurboReel.
+What stood out to Peter wasn't just that it was free, but that it was **open source**. *"I liked the idea of building on something maintained by a community, not locked behind a paywall"*, he says. Intrigued, Peter explored [Wasp](https://wasp.sh/) further and discovered an engaging community that offered exactly what he needed to start building TurboReel.
 
 Here's a video presenting Open SaaS, generated with TurboReel 🐝
 
@@ -138,4 +138,4 @@ Within a few days, he was able to get first paying customers, which proved that 
 
 ### Ready to Build Your SaaS?
 
-Get started with [Wasp](https://wasp-lang.dev/) today, or explore the [Open SaaS boilerplate](https://opensaas.sh/) to see how it can work for you.
+Get started with [Wasp](https://wasp.sh/) today, or explore the [Open SaaS boilerplate](https://opensaas.sh/) to see how it can work for you.

--- a/opensaas-sh/blog/src/content/docs/blog/2024-12-16-my-gpt-wrapper.mdx
+++ b/opensaas-sh/blog/src/content/docs/blog/2024-12-16-my-gpt-wrapper.mdx
@@ -24,7 +24,7 @@ I wanted to share my journey building a micro-SaaS, [CoverLetterGPT](https://cov
 ### Quick Stats:
 
 - **Built in 1 week** 
-  - using [Wasp](https://wasp-lang.dev/), a React, NodeJS, & Prisma framework
+  - using [Wasp](https://wasp.sh/), a React, NodeJS, & Prisma framework
   - and [Chakra UI](https://chakra-ui.com/) for the design system.
 - **Runs on autopilot**
 - **~$550 MRR** after one year
@@ -60,7 +60,7 @@ Here's why I think you should aim for small, achievable SaaS projects instead of
 The most important lesson I've learned: **speed is everything.** The faster you launch, the faster you'll know if your idea works. Here's what worked for me:
 
 1. **Avoid long, drawn-out failures:** Build small, execute early.
-2. **Use the fastest tools available:** I used [Wasp](https://wasp-lang.dev/) because it gives me all the building blocks already set up (auth, database, cron jobs, email sending), letting me focus on the business logic of the app. Paired with [Chakra UI](https://chakra-ui.com/), I was able to build the app in about 1 week.
+2. **Use the fastest tools available:** I used [Wasp](https://wasp.sh/) because it gives me all the building blocks already set up (auth, database, cron jobs, email sending), letting me focus on the business logic of the app. Paired with [Chakra UI](https://chakra-ui.com/), I was able to build the app in about 1 week.
 3. **Forget perfection:** I didn't worry about making it pretty or perfect—it just had to work.
 
 ### Keep It Simple
@@ -91,7 +91,7 @@ If you're thinking about launching your own SaaS, here are some helpful resource
 
 - 👨‍💻 [CoverLetterGPT (Live App)](https://coverlettergpt.xyz/)
 - 💸 [Open-Source SaaS Template](https://github.com/wasp-lang/open-saas)
-- 🛠️ [Framework: Wasp](https://wasp-lang.dev/)
+- 🛠️ [Framework: Wasp](https://wasp.sh/)
 - ✨ [UI Components: Chakra UI](https://chakra-ui.com/)
 - 🛠️ [Hosting: Railway](https://railway.app/) & [Netlify](https://netlify.com/)
 - ✍️ [My Original Reddit Post](https://www.reddit.com/r/SideProject/comments/1h4t8vk/my_saas_only_makes_550_a_month_and_i_think_thats/)

--- a/opensaas-sh/blog/src/content/docs/general/admin-dashboard.mdx
+++ b/opensaas-sh/blog/src/content/docs/general/admin-dashboard.mdx
@@ -2,7 +2,7 @@
 title: Admin Dashboard
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import dbStudio from '@assets/stripe/db-studio.png';
@@ -83,7 +83,7 @@ job dailyStatsJob {
   entities: [User, DailyStats, Logs, PageViewSource]
 }
 ```
-For more info on Wasp's recurring background jobs, check out the [Wasp Jobs docs](https://wasp-lang.dev/docs/advanced/jobs).
+For more info on Wasp's recurring background jobs, check out the [Wasp Jobs docs](https://wasp.sh/docs/advanced/jobs).
 
 For a guide on how to integrate these services so that you can view your analytics via the dashboard, check out the [Payments Integration](/guides/payments-integration/) and [Analytics guide](/guides/analytics/) of the docs.
 

--- a/opensaas-sh/blog/src/content/docs/general/user-overview.md
+++ b/opensaas-sh/blog/src/content/docs/general/user-overview.md
@@ -2,7 +2,7 @@
 title: User Overview
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 
 This reference will help you understand how the User entity works in this template.
@@ -34,7 +34,7 @@ entity User {=psl
 psl=}
 ```
 
-We store all pertinent information to the user, including identification, subscription, and payment processor information. Meanwhile, Wasp abstracts away all the Auth related entities dealing with `passwords`, `sessions`, and `socialLogins`, so you don't have to worry about these at all in your Prisma schema (if you want to learn more about this process, check out the [Wasp Auth Docs](https://wasp-lang.dev/docs/auth/overview)).
+We store all pertinent information to the user, including identification, subscription, and payment processor information. Meanwhile, Wasp abstracts away all the Auth related entities dealing with `passwords`, `sessions`, and `socialLogins`, so you don't have to worry about these at all in your Prisma schema (if you want to learn more about this process, check out the [Wasp Auth Docs](https://wasp.sh/docs/auth/overview)).
 
 ## Stripe and Subscriptions
 

--- a/opensaas-sh/blog/src/content/docs/guides/analytics.md
+++ b/opensaas-sh/blog/src/content/docs/guides/analytics.md
@@ -2,7 +2,7 @@
 title: Analytics
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 This guide will show you how to integrate analytics for your app. You can choose between [Google Analytics](#google-analytics) and [Plausible](#plausible).
 
@@ -58,7 +58,7 @@ As a completely free, open-source project, we appreciate any help 🙏
 
 ## Google Analytics
 
-First off, head over to `src/analytics/stats.ts` and switch out the Plausible Provider for Google Analytics so that your [background (cron) job](https://wasp-lang.dev/docs/advanced/jobs) fetches the data from Google Analytics for your [Admin Dashboard](/general/admin-dashboard/):
+First off, head over to `src/analytics/stats.ts` and switch out the Plausible Provider for Google Analytics so that your [background (cron) job](https://wasp.sh/docs/advanced/jobs) fetches the data from Google Analytics for your [Admin Dashboard](/general/admin-dashboard/):
 
 ```ts ins={3} del={2} title="stats.ts"
 //...

--- a/opensaas-sh/blog/src/content/docs/guides/authentication.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authentication.md
@@ -2,7 +2,7 @@
 title: Authentication
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 
 Setting up your app's authentication is easy with Wasp. In fact, it's already set up for you in the `main.wasp` file: 
@@ -26,7 +26,7 @@ The great part is, by defining your auth config in the `main.wasp` file, Wasp ma
 
 `email` method is the default auth method in Open Saas.
 
-Since it needs to send emails to verify users and reset passwords, it requires an [email sender](https://wasp-lang.dev/docs/advanced/email) provider: a service it can use to send emails.
+Since it needs to send emails to verify users and reset passwords, it requires an [email sender](https://wasp.sh/docs/advanced/email) provider: a service it can use to send emails.
 "email sender" provider is configured via `app.emailSender` field in the `main.wasp` file.
 
 :::caution[Dummy Email Provider]
@@ -79,15 +79,15 @@ In order to use the `email` auth method in production, you'll need to switch fro
 
 And that's it. Wasp will take care of the rest and update your AuthUI components accordingly.
 
-Check out the  [Wasp Auth docs](https://wasp-lang.dev/docs/auth/overview) for more info.
+Check out the  [Wasp Auth docs](https://wasp.sh/docs/auth/overview) for more info.
 
 ## Google, GitHub, & Discord Auth
 
 We've also customized and pre-built the Google and GitHub auth flow for you. To start using them, you just need to uncomment out the methods you want in your `main.wasp` file and obtain the proper API keys to add to your `.env.server` file. 
 
-To create a Google OAuth app and get your Google API keys, follow the instructions in [Wasp's Google Auth docs](https://wasp-lang.dev/docs/auth/social-auth/google#3-creating-a-google-oauth-app).
+To create a Google OAuth app and get your Google API keys, follow the instructions in [Wasp's Google Auth docs](https://wasp.sh/docs/auth/social-auth/google#3-creating-a-google-oauth-app).
 
-To create a GitHub OAuth app and get your GitHub API keys, follow the instructions in [Wasp's GitHub Auth docs](https://wasp-lang.dev/docs/auth/social-auth/github#3-creating-a-github-oauth-app).
+To create a GitHub OAuth app and get your GitHub API keys, follow the instructions in [Wasp's GitHub Auth docs](https://wasp.sh/docs/auth/social-auth/github#3-creating-a-github-oauth-app).
 
 To create a Discord OAuth app and get your Discord API keys, follow the instructions in [Wasp's Discord Auth docs](docs/auth/social-auth/google#3-creating-a-google-oauth-app)
 

--- a/opensaas-sh/blog/src/content/docs/guides/authorization.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authorization.md
@@ -2,7 +2,7 @@
 title: Authorization
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 
 This guide will help you get started with authorization in your SaaS app. 
@@ -13,7 +13,7 @@ Authorization differs from [authentication](/guides/authentication/) in that aut
 
 To learn more about the different types of user permissions built into this SaaS template, including Stripe subscription tiers and statuses, check out the [User Overview Reference](/general/user-overview/).
 
-Also, check out our [blog post](https://wasp-lang.dev/blog/2022/11/29/permissions-in-web-apps) to learn more about authorization (access control) in web apps.
+Also, check out our [blog post](https://wasp.sh/blog/2022/11/29/permissions-in-web-apps) to learn more about authorization (access control) in web apps.
 
 ### Client-side Authorization
 

--- a/opensaas-sh/blog/src/content/docs/guides/cookie-consent.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/cookie-consent.mdx
@@ -2,7 +2,7 @@
 title: Cookie Consent Modal
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import cookieBanner from '@assets/cookie-consent/cookiebanner.png';

--- a/opensaas-sh/blog/src/content/docs/guides/deploying.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/deploying.mdx
@@ -2,14 +2,14 @@
 title: Deploying
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import npmVersion from '@assets/stripe/npm-version.png';
 import stripeListenEvents from '@assets/stripe/listen-to-stripe-events.png';
 import stripeSigningSecret from '@assets/stripe/stripe-webhook-signing-secret.png';
 
-Because this SaaS app is a React/NodeJS/Postgres app built on top of [Wasp](https://wasp-lang.dev), Open SaaS can take advantage of Wasp's easy, one-command deploy to Fly.io or manual deploy to any provider of your choice.
+Because this SaaS app is a React/NodeJS/Postgres app built on top of [Wasp](https://wasp.sh), Open SaaS can take advantage of Wasp's easy, one-command deploy to Fly.io or manual deploy to any provider of your choice.
 
 The simplest and quickest option is to take advantage of Wasp's one-command deploy to Fly.io.
 
@@ -82,7 +82,7 @@ Here are a list of all of them (some of which you may not be using, e.g. Analyti
 
 **Wasp provides the handy `wasp deploy` command to deploy your entire full-stack app (DB, server, and client) in one command.**
 
-To learn how, please follow the detailed guide for [deploying to Fly via the Wasp CLI](https://wasp-lang.dev/docs/advanced/deployment/cli) from the Wasp documentation. We suggest you follow this guide carefully to get your app deployed.
+To learn how, please follow the detailed guide for [deploying to Fly via the Wasp CLI](https://wasp.sh/docs/deployment/deployment-methods/cli) from the Wasp documentation. We suggest you follow this guide carefully to get your app deployed.
 
 :::caution[Setting Environment Variables]
 Remember, because we've set certain client-side env variables, make sure to pass them to the `wasp deploy` commands so that they can be included in the build: 
@@ -97,12 +97,12 @@ The `wasp deploy` command will also take care of setting the following server-si
 - `WASP_WEB_CLIENT_URL`
 - `WASP_SERVER_URL`
 
-For setting the remaining server-side environment variables, please refer to the [Deploying with the Wasp CLI Guide](https://wasp-lang.dev/docs/advanced/deployment/cli#launch).
+For setting the remaining server-side environment variables, please refer to the [Deploying with the Wasp CLI Guide](https://wasp.sh/docs/deployment/deployment-methods/cli#launch).
 :::
 
 ### Deploying Manually / to Other Providers
 
-If you prefer to deploy manually, your frontend and backend separately, or just prefer using your favorite provider you can follow [Wasp's Manual Deployment Guide](https://wasp-lang.dev/docs/advanced/deployment/manually).
+If you prefer to deploy manually, your frontend and backend separately, or just prefer using your favorite provider you can follow [Wasp's Manual Deployment Guide](https://wasp.sh/docs/deployment/deployment-methods/paas).
 
 :::caution[Client-side Environment Variables]
 Remember to always set additional client-side environment variables, such as `REACT_APP_STRIPE_CUSTOMER_PORTAL` by appending them to the build command, e.g. 
@@ -115,8 +115,8 @@ REACT_APP_CLIENT_ENV_VAR_1=<...> npm run build
 
 After deploying your server, you need to add the correct redirect URIs to the credential settings. For this, refer to the following guides from the Wasp Docs:
 
-- [Google Auth](https://wasp-lang.dev/docs/auth/social-auth/google#3-creating-a-google-oauth-app:~:text=Under%20Authorized%20redirect%20URIs)
-- [Github Auth](https://wasp-lang.dev/docs/auth/social-auth/github#3-creating-a-github-oauth-app:~:text=Authorization%20callback%20URL)
+- [Google Auth](https://wasp.sh/docs/auth/social-auth/google#3-creating-a-google-oauth-app:~:text=Under%20Authorized%20redirect%20URIs)
+- [Github Auth](https://wasp.sh/docs/auth/social-auth/github#3-creating-a-github-oauth-app:~:text=Authorization%20callback%20URL)
 
 ### Setting up your Production Stripe Webhook
 

--- a/opensaas-sh/blog/src/content/docs/guides/email-sending.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/email-sending.mdx
@@ -2,7 +2,7 @@
 title: Email Sending
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
@@ -104,4 +104,4 @@ To set up your email sender, you first need an account with one of the supported
   </TabItem>
 </Tabs>
 
-If you want more detailed info, or would like to use SMTP, check out the [Wasp docs](https://wasp-lang.dev/docs/advanced/email).
+If you want more detailed info, or would like to use SMTP, check out the [Wasp docs](https://wasp.sh/docs/advanced/email).

--- a/opensaas-sh/blog/src/content/docs/guides/file-uploading.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/file-uploading.mdx
@@ -2,7 +2,7 @@
 title: File Uploading
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import findS3 from '@assets/file-uploads/find-s3.png';

--- a/opensaas-sh/blog/src/content/docs/guides/payments-integration.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/payments-integration.mdx
@@ -2,7 +2,7 @@
 title: Payments Integration
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import testApiKeys from '@assets/stripe/api-keys.png';

--- a/opensaas-sh/blog/src/content/docs/guides/seo.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/seo.mdx
@@ -2,7 +2,7 @@
 title: SEO
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import { Image } from 'astro:assets';
 import openSaaSGoogle from '@assets/seo/open-saas-google.png';

--- a/opensaas-sh/blog/src/content/docs/guides/tests.md
+++ b/opensaas-sh/blog/src/content/docs/guides/tests.md
@@ -2,7 +2,7 @@
 title: Tests
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 
 This guide will show you how to use the included end-to-end (e2e) tests for your Open SaaS application.

--- a/opensaas-sh/blog/src/content/docs/index.mdx
+++ b/opensaas-sh/blog/src/content/docs/index.mdx
@@ -2,7 +2,7 @@
 title: Introduction
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import HiddenLLMHelper from '../../components/HiddenLLMHelper.astro';
 
@@ -33,7 +33,7 @@ If you find this template useful, consider giving us [a star on GitHub](https://
 
 The template itself is built on top of some very powerful tools and frameworks, including:
 
-- 🐝 [Wasp](https://wasp-lang.dev) - a full-stack React, NodeJS, Prisma framework with superpowers
+- 🐝 [Wasp](https://wasp.sh) - a full-stack React, NodeJS, Prisma framework with superpowers
 - 🚀 [Astro](https://starlight.astro.build/) - Astro's lightweight "Starlight" template for documentation and blog
 - 💸 [Stripe](https://stripe.com) or [Lemon Squeezy](https://lemonsqueezy.com/) - for products and payments
 - 📈 [Plausible](https://plausible.io) or [Google](https://analytics.google.com/) Analytics
@@ -45,10 +45,10 @@ The template itself is built on top of some very powerful tools and frameworks, 
 
 Because we're using Wasp as the full-stack framework, we can leverage a lot of its features to build our SaaS in record time, including:
 
-- 🔐 [Full-stack Authentication](https://wasp-lang.dev/docs/auth/overview) - Email verified + social Auth in a few lines of code.
-- ⛑ [End-to-end Type Safety](https://wasp-lang.dev/docs/data-model/operations/overview) - Type your backend functions and get inferred types on the front-end automatically, without the need to install or configure any third-party libraries. Oh, and type-safe Links, too!
-- 🤖 [Jobs](https://wasp-lang.dev/docs/advanced/jobs) - Run cron jobs in the background or set up queues simply by defining a function in the config file.
-- 🚀 [One-command Deploy](https://wasp-lang.dev/docs/advanced/deployment/overview) - Easily deploy via the CLI to [Fly.io](https://fly.io), or to other providers like [Railway](https://railway.app) and [Netlify](https://netlify.com).
+- 🔐 [Full-stack Authentication](https://wasp.sh/docs/auth/overview) - Email verified + social Auth in a few lines of code.
+- ⛑ [End-to-end Type Safety](https://wasp.sh/docs/data-model/operations/overview) - Type your backend functions and get inferred types on the front-end automatically, without the need to install or configure any third-party libraries. Oh, and type-safe Links, too!
+- 🤖 [Jobs](https://wasp.sh/docs/advanced/jobs) - Run cron jobs in the background or set up queues simply by defining a function in the config file.
+- 🚀 [One-command Deploy](https://wasp.sh/docs/advanced/deployment/overview) - Easily deploy via the CLI to [Fly.io](https://fly.io), or to other providers like [Railway](https://railway.app) and [Netlify](https://netlify.com).
 
 You also get access to Wasp's diverse, helpful community if you get stuck or need help.
 - 🤝 [Wasp Discord](https://discord.gg/rzdnErX)

--- a/opensaas-sh/blog/src/content/docs/start/getting-started.mdx
+++ b/opensaas-sh/blog/src/content/docs/start/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 import VideoPlayer from '../../../components/VideoPlayer.astro';
 
@@ -83,7 +83,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 In order to use Wasp on Windows, you need to install WSL2 (Windows Subsystem for Linux) and a Linux distribution of your choice. We recommend using Ubuntu. 
 
-**You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) for a step by step guide to using Wasp in the WSL environment.** If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX).
+**You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) for a step by step guide to using Wasp in the WSL environment.** If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX).
 
 :::caution[WSL2 Docker post installation steps]
 

--- a/opensaas-sh/blog/src/content/docs/start/guided-tour.md
+++ b/opensaas-sh/blog/src/content/docs/start/guided-tour.md
@@ -2,7 +2,7 @@
 title: Guided Tour
 banner:
   content: |
-    Open SaaS is now running on <b><a href='https://wasp-lang.dev'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp-lang.dev/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
+    Open SaaS is now running on <b><a href='https://wasp.sh'>Wasp v0.16</a></b>! <br/>⚙️<br/>If you're running an older version and would like to upgrade, please follow the <a href="https://wasp.sh/docs/migration-guides/migrate-from-0-15-to-0-16">migration instructions.</a>
 ---
 
 Awesome, you now have your very own SaaS app up and running! But, first, here are some important things you need to know about your app in its current state:
@@ -86,25 +86,25 @@ If you are using an older version of the OpenSaaS template with Wasp `v0.13.x` o
 
 ### The Wasp Config file
 
-This template at its core is a Wasp project, where [Wasp](https://wasp-lang.dev) is a full-stack web app framework that let’s you write your app in React, NodeJS, and Prisma and will manage the "boilerplatey" work for you, allowing you to just take care of the fun stuff!
+This template at its core is a Wasp project, where [Wasp](https://wasp.sh) is a full-stack web app framework that let’s you write your app in React, NodeJS, and Prisma and will manage the "boilerplatey" work for you, allowing you to just take care of the fun stuff!
 
-[Wasp's secret sauce](https://wasp-lang.dev/docs) is its use of a config file (`main.wasp`) and compiler which takes your code and outputs the client app, server app and deployment code for you. 
+[Wasp's secret sauce](https://wasp.sh/docs) is its use of a config file (`main.wasp`) and compiler which takes your code and outputs the client app, server app and deployment code for you. 
 
 In this template, we've already defined a number of things in the `main.wasp` config file, including:
 
-- [Auth](https://wasp-lang.dev/docs/auth/overview)
-- [Routes and Pages](https://wasp-lang.dev/docs/tutorial/pages)
-- [Prisma Database Models](https://wasp-lang.dev/docs/data-model/entities)
-- [Operations (data read and write functions)](https://wasp-lang.dev/docs/data-model/operations/overview)
-- [Background Jobs](https://wasp-lang.dev/docs/advanced/jobs)
-- [Email Sending](https://wasp-lang.dev/docs/advanced/email)
+- [Auth](https://wasp.sh/docs/auth/overview)
+- [Routes and Pages](https://wasp.sh/docs/tutorial/pages)
+- [Prisma Database Models](https://wasp.sh/docs/data-model/entities)
+- [Operations (data read and write functions)](https://wasp.sh/docs/data-model/operations/overview)
+- [Background Jobs](https://wasp.sh/docs/advanced/jobs)
+- [Email Sending](https://wasp.sh/docs/advanced/email)
 
 By defining these things in the config file, Wasp continuously handles the boilerplate necessary with putting all these features together. You just need to focus on the business logic of your app.
 
 Wasp abstracts away some things that you would normally be used to doing during development, so don't be surprised if you don't see some of the things you're used to seeing.
 
 :::note
-It's possible to learn Wasp's feature set simply through using this template, but if you find yourself unsure how to implement a Wasp-specific feature and/or just want to learn more, a great starting point is the intro tutorial in the [Wasp docs](https://wasp-lang.dev/docs) which takes ~20 minutes.
+It's possible to learn Wasp's feature set simply through using this template, but if you find yourself unsure how to implement a Wasp-specific feature and/or just want to learn more, a great starting point is the intro tutorial in the [Wasp docs](https://wasp.sh/docs) which takes ~20 minutes.
 :::
 
 ### Client
@@ -139,7 +139,7 @@ The `src/server` folder contains any additional server-side code that does not b
 
 ### Auth
 
-This template comes with a fully functional auth flow out of the box. It takes advantages of Wasp's built-in [Auth features](https://wasp-lang.dev/docs/auth/overview), which do the dirty work of rolling your own full-stack auth for you!
+This template comes with a fully functional auth flow out of the box. It takes advantages of Wasp's built-in [Auth features](https://wasp.sh/docs/auth/overview), which do the dirty work of rolling your own full-stack auth for you!
 
 ```js title="main.wasp"
   auth: {
@@ -201,7 +201,7 @@ Let's take a quick look at how payments are handled in this template.
 
 The payment processor you choose (Stripe or Lemon Squeezy) and its related functions can be found at `src/payment/paymentProcessor.ts`. The `Payment Processor` object holds the logic for creating checkout sessions, webhooks, etc.
 
-The logic for creating the Checkout session is defined in the `src/payment/operation.ts` file. [Actions](https://wasp-lang.dev/docs/data-model/operations/actions) are a type of Wasp Operation, specifically your server-side functions that are used to **write** or **update** data to the database. Once they're defined in the `main.wasp` file, you can easily call them on the client-side:
+The logic for creating the Checkout session is defined in the `src/payment/operation.ts` file. [Actions](https://wasp.sh/docs/data-model/operations/actions) are a type of Wasp Operation, specifically your server-side functions that are used to **write** or **update** data to the database. Once they're defined in the `main.wasp` file, you can easily call them on the client-side:
 
 a) define the action in the `main.wasp` file
 ```js title="main.wasp"
@@ -254,7 +254,7 @@ Keeping an eye on your metrics is crucial for any SaaS. That's why we've built a
 
 <!-- TODO: add pic of admin dash -->
 
-To do that, we've leveraged Wasp's [Jobs feature](https://wasp-lang.dev/docs/advanced/jobs) to run a cron job that calculates your daily stats. The app stats, such as page views and sources, can be pulled from either Plausible or Google Analytics. All you have to do is create a project with the analytics provider of your choice and import the respective pre-built helper functions!
+To do that, we've leveraged Wasp's [Jobs feature](https://wasp.sh/docs/advanced/jobs) to run a cron job that calculates your daily stats. The app stats, such as page views and sources, can be pulled from either Plausible or Google Analytics. All you have to do is create a project with the analytics provider of your choice and import the respective pre-built helper functions!
 
 ```js title="main.wasp"
 job dailyStatsJob {
@@ -289,7 +289,7 @@ Now would be a good time to decide which features you do and do not need for you
 For the features you will use, the next section of the documentation, `Guides`, will walk you through how to set each one up!
 
 :::note[Open SaaS is built on Wasp]
-Remember, this template is built on the Wasp framework. If, at any time, these docs fail to provide enough information about a certain built-in feature, make sure to check out the [Wasp docs](https://wasp-lang.dev/docs)!
+Remember, this template is built on the Wasp framework. If, at any time, these docs fail to provide enough information about a certain built-in feature, make sure to check out the [Wasp docs](https://wasp.sh/docs)!
 :::
 
 But before you start setting up the main features, let's walk through the customizations you will likely want to make to the template to make it your own.

--- a/template/README.md
+++ b/template/README.md
@@ -1,7 +1,7 @@
 # <YOUR_APP_NAME>
 
 This project is based on [OpenSaas](https://opensaas.sh) template and consists of three main dirs:
-1. `app` - Your web app, built with [Wasp](https://wasp-lang.dev).
+1. `app` - Your web app, built with [Wasp](https://wasp.sh).
 2. `e2e-tests` - [Playwright](https://playwright.dev/) tests for your Wasp web app.
 3. `blog` - Your blog / docs, built with [Astro](https://docs.astro.build) based on [Starlight](https://starlight.astro.build/) template.
 

--- a/template/app/.env.client.example
+++ b/template/app/.env.client.example
@@ -1,4 +1,4 @@
-# All client-side env vars must start with REACT_APP_ https://wasp-lang.dev/docs/project/env-vars
+# All client-side env vars must start with REACT_APP_ https://wasp.sh/docs/project/env-vars
 
 # See https://docs.opensaas.sh/guides/analytics/#google-analytics
 REACT_APP_GOOGLE_ANALYTICS_ID=G-...

--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -26,7 +26,7 @@ PAYMENTS_CREDITS_10_PLAN_ID=012345
 # set this as a comma-separated list of emails you want to give admin privileges to upon registeration
 ADMIN_EMAILS=me@example.com,you@example.com,them@example.com
 
-# see our guide for setting up google auth: https://wasp-lang.dev/docs/auth/social-auth/google
+# see our guide for setting up google auth: https://wasp.sh/docs/auth/social-auth/google
 GOOGLE_CLIENT_ID=722...
 GOOGLE_CLIENT_SECRET=GOC...
 

--- a/template/app/README.md
+++ b/template/app/README.md
@@ -1,6 +1,6 @@
 # <YOUR_APP_NAME>
 
-Built with [Wasp](https://wasp-lang.dev), based on the [Open Saas](https://opensaas.sh) template.
+Built with [Wasp](https://wasp.sh), based on the [Open Saas](https://opensaas.sh) template.
 
 ## Development
 

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -145,8 +145,8 @@ action updateCurrentUserLastActiveTimestamp {
   entities: [User]
 }
 
-action updateUserById {
-  fn: import { updateUserById } from "@src/user/operations",
+action updateIsUserAdminById {
+  fn: import { updateIsUserAdminById } from "@src/user/operations",
   entities: [User]
 }
 //#endregion

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -29,7 +29,7 @@ app OpenSaaS {
     "<script defer data-domain='<your-site-id>' src='https://plausible.io/js/script.local.js'></script>",  // for development
   ],
 
-  // 🔐 Auth out of the box! https://wasp-lang.dev/docs/auth/overview
+  // 🔐 Auth out of the box! https://wasp.sh/docs/auth/overview
   auth: {
     userEntity: User,
     methods: {
@@ -50,17 +50,17 @@ app OpenSaaS {
         },
         userSignupFields: import { getEmailUserFields } from "@src/auth/userSignupFields",
       },
-      // Uncomment to enable Google Auth (check https://wasp-lang.dev/docs/auth/social-auth/google for setup instructions):
+      // Uncomment to enable Google Auth (check https://wasp.sh/docs/auth/social-auth/google for setup instructions):
       // google: { // Guide for setting up Auth via Google
       //   userSignupFields: import { getGoogleUserFields } from "@src/auth/userSignupFields",
       //   configFn: import { getGoogleAuthConfig } from "@src/auth/userSignupFields",
       // },
-      // Uncomment to enable GitHub Auth (check https://wasp-lang.dev/docs/auth/social-auth/github for setup instructions):
+      // Uncomment to enable GitHub Auth (check https://wasp.sh/docs/auth/social-auth/github for setup instructions):
       // gitHub: {
       //   userSignupFields: import { getGitHubUserFields } from "@src/auth/userSignupFields",
       //   configFn: import { getGitHubAuthConfig } from "@src/auth/userSignupFields",
       // },
-      // Uncomment to enable Discord Auth (check https://wasp-lang.dev/docs/auth/social-auth/discord for setup instructions):
+      // Uncomment to enable Discord Auth (check https://wasp.sh/docs/auth/social-auth/discord for setup instructions):
       // discord: {
       //   userSignupFields: import { getDiscordUserFields } from "@src/auth/userSignupFields",
       //   configFn: import { getDiscordAuthConfig } from "@src/auth/userSignupFields"

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -140,8 +140,8 @@ query getPaginatedUsers {
   entities: [User]
 }
 
-action updateCurrentUser {
-  fn: import { updateCurrentUser } from "@src/user/operations",
+action updateCurrentUserLastActiveTimestamp {
+  fn: import { updateCurrentUserLastActiveTimestamp } from "@src/user/operations",
   entities: [User]
 }
 

--- a/template/app/src/admin/dashboards/users/SwitcherOne.tsx
+++ b/template/app/src/admin/dashboards/users/SwitcherOne.tsx
@@ -2,7 +2,7 @@ import { type User } from 'wasp/entities';
 import { useState } from 'react';
 import { cn } from '../../../client/cn';
 
-const SwitcherOne = ({ user, updateUserById }: { user?: Partial<User>; updateUserById?: any }) => {
+const SwitcherOne = ({ user, updateIsUserAdminById }: { user?: Partial<User>; updateIsUserAdminById?: any }) => {
   const [enabled, setEnabled] = useState<boolean>(user?.isAdmin || false);
 
   return (
@@ -15,7 +15,7 @@ const SwitcherOne = ({ user, updateUserById }: { user?: Partial<User>; updateUse
             className='sr-only'
             onChange={() => {
               setEnabled(!enabled);
-              updateUserById && updateUserById({ id: user?.id, data: { isAdmin: !enabled } });
+              updateIsUserAdminById && updateIsUserAdminById({ id: user?.id, data: { isAdmin: !enabled } });
             }}
           />
           <div className='reblock h-8 w-14 rounded-full bg-meta-9 dark:bg-[#5A616B]'></div>

--- a/template/app/src/admin/dashboards/users/UsersTable.tsx
+++ b/template/app/src/admin/dashboards/users/UsersTable.tsx
@@ -1,5 +1,5 @@
 import { type SubscriptionStatus } from '../../../payment/plans';
-import { updateUserById, useQuery, getPaginatedUsers } from 'wasp/client/operations';
+import { updateIsUserAdminById, useQuery, getPaginatedUsers } from 'wasp/client/operations';
 import { useState, useEffect } from 'react';
 import SwitcherOne from './SwitcherOne';
 import LoadingSpinner from '../../layout/LoadingSpinner';
@@ -226,7 +226,7 @@ const UsersTable = () => {
               </div>
               <div className='col-span-1 flex items-center'>
                 <div className='text-sm text-black dark:text-white'>
-                  <SwitcherOne user={user} updateUserById={updateUserById} />
+                  <SwitcherOne user={user} updateIsUserAdminById={updateIsUserAdminById} />
                 </div>
               </div>
               <div className='col-span-1 flex items-center'>

--- a/template/app/src/client/App.tsx
+++ b/template/app/src/client/App.tsx
@@ -8,7 +8,7 @@ import { routes } from 'wasp/client/router';
 import { Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from 'wasp/client/auth';
 import { useIsLandingPage } from './hooks/useIsLandingPage';
-import { updateCurrentUser } from 'wasp/client/operations';
+import { updateCurrentUserLastActiveTimestamp } from 'wasp/client/operations';
 
 /**
  * use this component to wrap all child components
@@ -33,7 +33,7 @@ export default function App() {
       const lastSeenAt = new Date(user.lastActiveTimestamp);
       const today = new Date();
       if (today.getTime() - lastSeenAt.getTime() > 5 * 60 * 1000) {
-        updateCurrentUser({ lastActiveTimestamp: today });
+        updateCurrentUserLastActiveTimestamp({ lastActiveTimestamp: today });
       }
     }
   }, [user]);

--- a/template/app/src/landing-page/contentSections.ts
+++ b/template/app/src/landing-page/contentSections.ts
@@ -74,7 +74,7 @@ export const footerNavigation = {
     { name: 'Blog', href: BlogUrl },
   ],
   company: [
-    { name: 'About', href: 'https://wasp-lang.dev' },
+    { name: 'About', href: 'https://wasp.sh' },
     { name: 'Privacy', href: '#' },
     { name: 'Terms of Service', href: '#' },
   ],

--- a/template/app/src/payment/stripe/checkoutUtils.ts
+++ b/template/app/src/payment/stripe/checkoutUtils.ts
@@ -2,7 +2,7 @@ import type { StripeMode } from './paymentProcessor';
 import Stripe from 'stripe';
 import { stripe } from './stripeClient';
 
-// WASP_WEB_CLIENT_URL will be set up by Wasp when deploying to production: https://wasp-lang.dev/docs/deploying
+// WASP_WEB_CLIENT_URL will be set up by Wasp when deploying to production: https://wasp.sh/docs/deploying
 const DOMAIN = process.env.WASP_WEB_CLIENT_URL || 'http://localhost:3000';
 
 export async function fetchStripeCustomer(customerEmail: string) {

--- a/template/app/src/server/scripts/dbSeeds.ts
+++ b/template/app/src/server/scripts/dbSeeds.ts
@@ -8,7 +8,7 @@ type MockUserData = Omit<User, 'id'>;
 /**
  * This function, which we've imported in `app.db.seeds` in the `main.wasp` file,
  * seeds the database with mock users via the `wasp db seed` command.
- * For more info see: https://wasp-lang.dev/docs/data-model/backends#seeding-the-database
+ * For more info see: https://wasp.sh/docs/data-model/backends#seeding-the-database
  */
 export async function seedMockUsers(prismaClient: PrismaClient) {
   await Promise.all(generateMockUsersData(50).map((data) => 

--- a/template/app/src/user/operations.ts
+++ b/template/app/src/user/operations.ts
@@ -1,5 +1,5 @@
 import {
-  type UpdateCurrentUser,
+  type UpdateCurrentUserLastActiveTimestamp,
   type UpdateUserById,
   type GetPaginatedUsers,
 } from 'wasp/server/operations';
@@ -29,7 +29,7 @@ export const updateUserById: UpdateUserById<{ id: string; data: Partial<User> },
   return updatedUser;
 };
 
-export const updateCurrentUser: UpdateCurrentUser<Pick<User, 'lastActiveTimestamp'>, User> = async ({ lastActiveTimestamp }, context) => {
+export const updateCurrentUserLastActiveTimestamp: UpdateCurrentUserLastActiveTimestamp<Pick<User, 'lastActiveTimestamp'>, User> = async ({ lastActiveTimestamp }, context) => {
   if (!context.user) {
     throw new HttpError(401);
   }

--- a/template/app/src/user/operations.ts
+++ b/template/app/src/user/operations.ts
@@ -1,13 +1,13 @@
 import {
   type UpdateCurrentUserLastActiveTimestamp,
-  type UpdateUserById,
+  type UpdateIsUserAdminById,
   type GetPaginatedUsers,
 } from 'wasp/server/operations';
 import { type User } from 'wasp/entities';
 import { HttpError } from 'wasp/server';
 import { type SubscriptionStatus } from '../payment/plans';
 
-export const updateUserById: UpdateUserById<{ id: string; data: Partial<User> }, User> = async (
+export const updateIsUserAdminById: UpdateIsUserAdminById<{ id: string; data: Pick<User, 'isAdmin'> }, User> = async (
   { id, data },
   context
 ) => {
@@ -23,7 +23,9 @@ export const updateUserById: UpdateUserById<{ id: string; data: Partial<User> },
     where: {
       id,
     },
-    data,
+    data: {
+      isAdmin: data.isAdmin,
+    },
   });
 
   return updatedUser;

--- a/template/app/src/user/operations.ts
+++ b/template/app/src/user/operations.ts
@@ -29,7 +29,7 @@ export const updateUserById: UpdateUserById<{ id: string; data: Partial<User> },
   return updatedUser;
 };
 
-export const updateCurrentUser: UpdateCurrentUser<Partial<User>, User> = async (user, context) => {
+export const updateCurrentUser: UpdateCurrentUser<Pick<User, 'lastActiveTimestamp'>, User> = async ({ lastActiveTimestamp }, context) => {
   if (!context.user) {
     throw new HttpError(401);
   }
@@ -38,7 +38,7 @@ export const updateCurrentUser: UpdateCurrentUser<Partial<User>, User> = async (
     where: {
       id: context.user.id,
     },
-    data: user,
+    data: {lastActiveTimestamp},
   });
 };
 

--- a/template/blog/src/content/docs/blog/2023-11-21-coverlettergpt.md
+++ b/template/blog/src/content/docs/blog/2023-11-21-coverlettergpt.md
@@ -7,7 +7,7 @@ hideBannerImage: false # Banner images stored in public/banner-images/ are autom
 authors:
   - name: vince
     title: Dev Rel @ Wasp
-    url: https://wasp-lang.dev
+    url: https://wasp.sh
 ---
 ## Hey, I’m Vince…
 
@@ -44,15 +44,15 @@ It also lets you save and manage your cover letters per each job, making it easy
 
 CoverLetterGPT is entirely open-source, so you can [check out the code](https://github.com/vincanger/coverlettergpt), fork it, learn from it, make your own, submit a PR (I’d love you forever if you did 🙂)… whatever!
 
-I built it using the [Wasp full-stack framework](https://wasp-lang.dev) which allowed me to ship it about 10x faster. 
+I built it using the [Wasp full-stack framework](https://wasp.sh) which allowed me to ship it about 10x faster. 
 
 Why? 
 
-Because [Wasp](https://wasp-lang.dev) as a framework allows you to describe your app’s core features in a `main.wasp` config file. Then it continually compiles and “glues” these features into a React-ExpressJS-Prisma full-stack app for you. 
+Because [Wasp](https://wasp.sh) as a framework allows you to describe your app’s core features in a `main.wasp` config file. Then it continually compiles and “glues” these features into a React-ExpressJS-Prisma full-stack app for you. 
 
 All you have to focus on is writing the client and server-side logic, and Wasp will do the boring stuff for you, like authentication & authorization, server config, email sending, and cron jobs. 
 
-BTW, [Wasp](https://wasp-lang.dev) is open-source and free and you can help the project out a ton by starring the repo on GitHub: [https://www.github.com/wasp-lang/wasp](https://www.github.com/wasp-lang/wasp) 🙏
+BTW, [Wasp](https://wasp.sh) is open-source and free and you can help the project out a ton by starring the repo on GitHub: [https://www.github.com/wasp-lang/wasp](https://www.github.com/wasp-lang/wasp) 🙏
 
 ![https://media1.giphy.com/media/ZfK4cXKJTTay1Ava29/giphy.gif?cid=7941fdc6pmqo30ll0e4rzdiisbtagx97sx5t0znx4lk0auju&ep=v1_gifs_search&rid=giphy.gif&ct=g](https://media1.giphy.com/media/ZfK4cXKJTTay1Ava29/giphy.gif?cid=7941fdc6pmqo30ll0e4rzdiisbtagx97sx5t0znx4lk0auju&ep=v1_gifs_search&rid=giphy.gif&ct=g)
 

--- a/template/e2e-tests/README.md
+++ b/template/e2e-tests/README.md
@@ -23,7 +23,8 @@ Open another terminal and start the Wasp app with the environment variable set t
 cd app && SKIP_EMAIL_VERIFICATION_IN_DEV=true wasp start
 ```
 
-NOTE: When using the email auth method a verification link is sent when the user registers, or logged to the console if you're using the default Dummy provider. You must click this link to complete registration. Setting SKIP_EMAIL_VERIFICATION_IN_DEV to "true" skips this verification step, allowing you to automatically log in. This step must be skipped when running tests, otherwise the tests will hang and fail as the verification link is never clicked!
+> [!IMPORTANT]  
+> When using the email auth method a verification link is sent when the user registers, or logged to the console if you're using the default Dummy provider. You must click this link to complete registration. Setting SKIP_EMAIL_VERIFICATION_IN_DEV to "true" skips this verification step, allowing you to automatically log in. This step must be skipped when running tests, otherwise the tests will hang and fail as the verification link is never clicked!
 
 In another terminal, run the local e2e tests:
 ```shell


### PR DESCRIPTION
## Description

- updates mentions of wasp url to wasp.sh!
- fixes #360 as well in the process
- reduces `updateCurrentUser` to only accept `lastActiveTimestamp`

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
