### PR TITLE
return user id and timestamp only from updateUserTimestamp

### DIFF
--- a/opensaas-sh/blog/src/content/docs/guides/authorization.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authorization.md
@@ -79,7 +79,7 @@ Authorization on the server-side is the core of your access control logic, and d
 You can authorize access to server-side operations by adding a check for a logged-in user on the `context.user` object which is passed to all operations in Wasp:
 
 ```tsx title="src/server/actions.ts" 
-export const updateCurrentUser: UpdateCurrentUser<...> = async (args, context) => {
+export const someServerAction: SomeServerAction<...> = async (args, context) => {
   if (!context.user) {
     throw new HttpError(401); // throw an error if user is not logged in
   }

--- a/template/app/src/client/App.tsx
+++ b/template/app/src/client/App.tsx
@@ -33,7 +33,7 @@ export default function App() {
       const lastSeenAt = new Date(user.lastActiveTimestamp);
       const today = new Date();
       if (today.getTime() - lastSeenAt.getTime() > 5 * 60 * 1000) {
-        updateCurrentUserLastActiveTimestamp({ lastActiveTimestamp: today });
+        updateCurrentUserLastActiveTimestamp();
       }
     }
   }, [user]);

--- a/template/app/src/user/operations.ts
+++ b/template/app/src/user/operations.ts
@@ -31,7 +31,7 @@ export const updateIsUserAdminById: UpdateIsUserAdminById<{ id: string; data: Pi
   return updatedUser;
 };
 
-export const updateCurrentUserLastActiveTimestamp: UpdateCurrentUserLastActiveTimestamp<Pick<User, 'lastActiveTimestamp'>, User> = async ({ lastActiveTimestamp }, context) => {
+export const updateCurrentUserLastActiveTimestamp: UpdateCurrentUserLastActiveTimestamp<void, Pick<User, 'id' | 'lastActiveTimestamp'>> = async (_args, context) => {
   if (!context.user) {
     throw new HttpError(401);
   }
@@ -40,7 +40,13 @@ export const updateCurrentUserLastActiveTimestamp: UpdateCurrentUserLastActiveTi
     where: {
       id: context.user.id,
     },
-    data: {lastActiveTimestamp},
+    data: {
+      lastActiveTimestamp: new Date(),
+    },
+    select: {
+      id: true,
+      lastActiveTimestamp: true,
+    },
   });
 };
 


### PR DESCRIPTION
## Description

Updates `updateUserLastActiveTimestamp` to not return entire User object.

Renames `updateCurrentUser` to a more generic function name in the authorization docs.

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
