### PR TITLE
Fix imports to avoid client-side errors

### DIFF
--- a/template/app/src/payment/lemonSqueezy/paymentProcessor.ts
+++ b/template/app/src/payment/lemonSqueezy/paymentProcessor.ts
@@ -1,5 +1,5 @@
 import type { CreateCheckoutSessionArgs, FetchCustomerPortalUrlArgs, PaymentProcessor } from '../paymentProcessor';
-import { requireNodeEnvVar } from '../../server/utils';
+import { requireNodeEnvVar } from '../../server/envUtils';
 import { createLemonSqueezyCheckoutSession } from './checkoutUtils';
 import { lemonSqueezyWebhook, lemonSqueezyMiddlewareConfigFn } from './webhook';
 import { lemonSqueezySetup } from '@lemonsqueezy/lemonsqueezy.js';

--- a/template/app/src/payment/lemonSqueezy/webhook.ts
+++ b/template/app/src/payment/lemonSqueezy/webhook.ts
@@ -6,7 +6,7 @@ import { paymentPlans, PaymentPlanId } from '../plans';
 import { updateUserLemonSqueezyPaymentDetails } from './paymentDetails';
 import { type Order, type Subscription, getCustomer } from '@lemonsqueezy/lemonsqueezy.js';
 import crypto from 'crypto';
-import { requireNodeEnvVar } from '../../server/utils';
+import { requireNodeEnvVar } from '../../server/envUtils';
 
 
 export const lemonSqueezyWebhook: PaymentsWebhook = async (request, response, context) => {

--- a/template/app/src/payment/plans.ts
+++ b/template/app/src/payment/plans.ts
@@ -1,4 +1,4 @@
-import { requireNodeEnvVar } from '../server/utils';
+import { requireNodeEnvVar } from '../server/envUtils';
 
 export type SubscriptionStatus = 'past_due' | 'cancel_at_period_end' | 'active' | 'deleted';
 

--- a/template/app/src/payment/stripe/paymentProcessor.ts
+++ b/template/app/src/payment/stripe/paymentProcessor.ts
@@ -1,7 +1,7 @@
 import type { PaymentPlanEffect } from '../plans';
 import type { CreateCheckoutSessionArgs, FetchCustomerPortalUrlArgs, PaymentProcessor } from '../paymentProcessor'
 import { fetchStripeCustomer, createStripeCheckoutSession } from './checkoutUtils';
-import { requireNodeEnvVar } from '../../server/utils';
+import { requireNodeEnvVar } from '../../server/envUtils';
 import { stripeWebhook, stripeMiddlewareConfigFn } from './webhook';
 
 export type StripeMode = 'subscription' | 'payment';

--- a/template/app/src/payment/stripe/stripeClient.ts
+++ b/template/app/src/payment/stripe/stripeClient.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { requireNodeEnvVar } from '../../server/utils';
+import { requireNodeEnvVar } from '../../server/envUtils';
 
 export const stripe = new Stripe(requireNodeEnvVar('STRIPE_API_KEY'), {
   // NOTE:

--- a/template/app/src/payment/stripe/webhook.ts
+++ b/template/app/src/payment/stripe/webhook.ts
@@ -8,7 +8,7 @@ import { paymentPlans, PaymentPlanId, SubscriptionStatus } from '../plans';
 import { updateUserStripePaymentDetails } from './paymentDetails';
 import { emailSender } from 'wasp/server/email';
 import { assertUnreachable } from '../../shared/utils';
-import { requireNodeEnvVar } from '../../server/utils';
+import { requireNodeEnvVar } from '../../server/envUtils';
 import { z } from 'zod';
 
 export const stripeWebhook: PaymentsWebhook = async (request, response, context) => {

--- a/template/app/src/server/envUtils.ts
+++ b/template/app/src/server/envUtils.ts
@@ -1,0 +1,8 @@
+export function requireNodeEnvVar(name: string): string {
+  const value = process.env[name];
+  if (value === undefined) {
+    throw new Error(`Env var ${name} is undefined`);
+  } else {
+    return value;
+  }
+}

--- a/template/app/src/server/utils.ts
+++ b/template/app/src/server/utils.ts
@@ -1,8 +1,0 @@
-export function requireNodeEnvVar(name: string): string {
-  const value = process.env[name];
-  if (value === undefined) {
-    throw new Error(`Env var ${name} is undefined`);
-  } else {
-    return value;
-  }
-}


### PR DESCRIPTION
Fixes #370

Organize `server/utils.ts` functions to avoid client-side imports.

* Add `template/app/src/server/envUtils.ts` to contain the `requireNodeEnvVar` function.
* Remove `requireNodeEnvVar` function from `template/app/src/server/utils.ts`.
* Update imports of `requireNodeEnvVar` in `template/app/src/payment/plans.ts`, `template/app/src/payment/lemonSqueezy/paymentProcessor.ts`, `template/app/src/payment/stripe/paymentProcessor.ts`, `template/app/src/payment/stripe/stripeClient.ts`, `template/app/src/payment/lemonSqueezy/webhook.ts`, and `template/app/src/payment/stripe/webhook.ts` to import from `template/app/src/server/envUtils.ts`.