### PR TITLE
improve one-time payment webhook logic

### DIFF
--- a/opensaas-sh/app_diff/src/payment/stripe/paymentProcessor.ts.diff
+++ b/opensaas-sh/app_diff/src/payment/stripe/paymentProcessor.ts.diff
@@ -1,6 +1,6 @@
 --- template/app/src/payment/stripe/paymentProcessor.ts
 +++ opensaas-sh/app/src/payment/stripe/paymentProcessor.ts
-@@ -21,7 +21,7 @@
+@@ -20,7 +20,7 @@
          id: userId
        },
        data: {

--- a/opensaas-sh/blog/src/content/docs/guides/deploying.mdx
+++ b/opensaas-sh/blog/src/content/docs/guides/deploying.mdx
@@ -178,6 +178,7 @@ export const stripe = new Stripe(process.env.STRIPE_KEY!, {
   <br/>- `customer.subscription.deleted`
   <br/>- `customer.subscription.updated`
   <br/>- `invoice.paid`
+  <br/>- `payment_intent.succeeded`
 <Image src={stripeSigningSecret} alt="signing secret" loading="lazy" />
 5. after that, go to the webhook you just created and `reveal` the new signing secret.
 6. add this secret to your deployed server's `STRIPE_WEBHOOK_SECRET=` environment variable. <br/>If you've deployed to Fly.io, you can do that easily with the following command:

--- a/template/app/src/payment/stripe/paymentProcessor.ts
+++ b/template/app/src/payment/stripe/paymentProcessor.ts
@@ -11,7 +11,6 @@ export const stripePaymentProcessor: PaymentProcessor = {
   createCheckoutSession: async ({ userId, userEmail, paymentPlan, prismaUserDelegate }: CreateCheckoutSessionArgs) => {
     const customer = await fetchStripeCustomer(userEmail);
     const stripeSession = await createStripeCheckoutSession({
-      userId,
       priceId: paymentPlan.getPaymentProcessorPlanId(),
       customerId: customer.id,
       mode: paymentPlanEffectToStripeMode(paymentPlan.effect),

--- a/template/e2e-tests/tests/demoAppTests.spec.ts
+++ b/template/e2e-tests/tests/demoAppTests.spec.ts
@@ -89,9 +89,9 @@ test('AI schedule generation fails on 4th attempt', async () => {
   expect(tableTextContent.includes(task2.toLowerCase())).toBeFalsy();
 });
 
-test('Make test payment with Stripe', async () => {
-  const PLAN_NAME = 'Hobby';
-  await makeStripePayment({ test, page, planName: PLAN_NAME });
+test('Make test payment with Stripe for hobby plan', async () => {
+  const planId = 'hobby';
+  await makeStripePayment({ test, page, planId });
 });
 
 test('User should be able to generate another schedule after payment', async () => {


### PR DESCRIPTION
## Description

Fixes #371 

Adds a new webhook event handler for `payment_intent.succeeded`. One-time payment products (i.e. "credits"), characterized by Stripe as having the `payment` mode (not the `subscription` mode), do not send an `invoice.paid` event (although subscriptions do), so we have to confirm payment and handle it better than just using the `checkout.session.completed` event, which can be sent even in the case that a payment fails.

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [x] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
