### PR TITLE
Update codebase to use the latest install WASP command

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v ${{ env.WASP_VERSION }}
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v ${{ env.WASP_VERSION }}
 
       - name: Cache global node modules
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You also get access to Wasp's diverse, helpful community if you get stuck or nee
 
 First, to install the latest version of [Wasp](https://wasp.sh/) on macOS, Linux, or Windows with WSL, run the following command:
 ```bash
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 Then, create a new SaaS app with the following command:

--- a/opensaas-sh/blog/src/content/docs/start/getting-started.mdx
+++ b/opensaas-sh/blog/src/content/docs/start/getting-started.mdx
@@ -61,7 +61,7 @@ To switch easily between Node.js versions, we recommend using [nvm](https://gith
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::caution[Bad CPU type in executable]
@@ -117,7 +117,7 @@ su -s $USER
 
 Once in WSL2, run the following command in your **WSL2 environment**:
 ```sh
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::caution[WSL2 and file system issues]


### PR DESCRIPTION
## Description

On the popular Open SaaS template, I updated the README to use the most up to date URL for installing Wasp :)

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

N/A

- [~] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [~] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [~] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
