### PR TITLE
Upgrade Stripe SDK to Support 100% Off Coupons

### DIFF
--- a/template/app/package.json
+++ b/template/app/package.json
@@ -24,7 +24,7 @@
     "react-hot-toast": "^2.4.1",
     "react-icons": "4.11.0",
     "react-router-dom": "^6.26.2",
-    "stripe": "11.15.0",
+    "stripe": "17.7.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.2.7",
     "vanilla-cookieconsent": "^3.0.1",

--- a/template/app/src/payment/stripe/checkoutUtils.ts
+++ b/template/app/src/payment/stripe/checkoutUtils.ts
@@ -54,6 +54,7 @@ export async function createStripeCheckoutSession({
       success_url: `${DOMAIN}/checkout?success=true`,
       cancel_url: `${DOMAIN}/checkout?canceled=true`,
       automatic_tax: { enabled: true },
+      allow_promotion_codes: true,
       customer_update: {
         address: 'auto',
       },

--- a/template/app/src/payment/stripe/stripeClient.ts
+++ b/template/app/src/payment/stripe/stripeClient.ts
@@ -8,5 +8,5 @@ export const stripe = new Stripe(requireNodeEnvVar('STRIPE_API_KEY'), {
   // npm package to the API version that matches your Stripe dashboard's one.
   // For more details and alternative setups check
   // https://docs.stripe.com/api/versioning .
-  apiVersion: '2022-11-15',
+  apiVersion: '2025-02-24.acacia',
 });


### PR DESCRIPTION
## Description

Fixes #229 

This PR updates the Stripe SDK (2025-02-24.acacia) to enable support for 100% off coupon codes during checkout. Stripe only allows no-cost (free) orders starting from API version 2023-08-16. By default, the checkout will allow promo codes. 

Reference: [Stripe API Changelog – 2023-08-16](https://docs.stripe.com/upgrades#2023-08-16)


![Screenshot 2025-04-01 at 6 06 27 PM](https://github.com/user-attachments/assets/0bb4f63d-34bc-4727-a3c9-ae6e2bce41a7)



## Contributor Checklist

- [x] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
