### PR TITLE
Fix typo in header branding and add Jon Cocharan’s profile image and X.com link

### DIFF
--- a/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
@@ -14,9 +14,9 @@
            >
              <NavLogo />
 -            {isLandingPage && (
--              <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your Saas</span>
+-              <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your SaaS</span>
 -            )}
-+            {isLandingPage && <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Open Saas</span>}
++            {isLandingPage && <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Open SaaS</span>}
            </WaspRouterLink>
          </div>
          <div className='flex lg:hidden'>

--- a/opensaas-sh/app_diff/src/landing-page/contentSections.ts.diff
+++ b/opensaas-sh/app_diff/src/landing-page/contentSections.ts.diff
@@ -139,8 +139,8 @@
 +  {
 +    name: 'Jonathan Cocharan',
 +    role: 'Entrepreneur',
-+    avatarSrc: 'https://pbs.twimg.com/profile_images/926142421653753857/o6Hmcbr7_400x400.jpg',
-+    socialUrl: 'https://twitter.com/jonathancocharan',
++    avatarSrc: 'https://pbs.twimg.com/profile_images/1910056203863883776/jtfVWaEG_400x400.jpg',
++    socialUrl: 'https://twitter.com/JonathanCochran',
 +    quote:
 +      'In just 6 nights... my SaaS app is live 🎉! Huge thanks to the amazing @wasplang community 🙌 for their guidance along the way. These tools are incredibly efficient 🤯!',
    },

--- a/template/app/src/client/components/NavBar/NavBar.tsx
+++ b/template/app/src/client/components/NavBar/NavBar.tsx
@@ -41,7 +41,7 @@ export default function AppNavBar({ navigationItems }: { navigationItems: Naviga
           >
             <NavLogo />
             {isLandingPage && (
-              <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your Saas</span>
+              <span className='ml-2 text-sm font-semibold leading-6 dark:text-white'>Your SaaS</span>
             )}
           </WaspRouterLink>
         </div>


### PR DESCRIPTION



This PR addresses and fixes issue #423 by implementing the following changes:

✅ Corrected the branding text in the top-left corner from "Open Saas" to "Open SaaS".

✅ Updated Jon Cocharan’s correct profile thumbnail to the team/contributors section.

✅ Included a working link to Jon Cocharan’s X.com (formerly Twitter) account.