### PR TITLE
Update Open SaaS meta tags and Hero description

### DIFF
--- a/opensaas-sh/app_diff/main.wasp.diff
+++ b/opensaas-sh/app_diff/main.wasp.diff
@@ -28,7 +28,7 @@
 -    "<meta name='twitter:image' content='https://your-saas-app.com/public-banner.webp' />",
 +    "<meta property='og:title' content='Open SaaS' />",
 +    "<meta property='og:url' content='https://opensaas.sh' />",
-+    "<meta property='og:description' content='Free, open-source SaaS boilerplate starter for React & NodeJS. Built by Wasp.' />",
++    "<meta property='og:description' content='Free, open-source SaaS boilerplate starter for React & NodeJS. Powered by Wasp.' />",
 +    "<meta property='og:image' content='https://opensaas.sh/public-banner.webp' />",
 +
 +    "<meta name=\"twitter:title\" content=\"Open SaaS\" />",

--- a/opensaas-sh/app_diff/main.wasp.diff
+++ b/opensaas-sh/app_diff/main.wasp.diff
@@ -28,7 +28,7 @@
 -    "<meta name='twitter:image' content='https://your-saas-app.com/public-banner.webp' />",
 +    "<meta property='og:title' content='Open SaaS' />",
 +    "<meta property='og:url' content='https://opensaas.sh' />",
-+    "<meta property='og:description' content='Free, open-source SaaS boilerplate starter for React & NodeJS.' />",
++    "<meta property='og:description' content='Free, open-source SaaS boilerplate starter for React & NodeJS. Built by Wasp.' />",
 +    "<meta property='og:image' content='https://opensaas.sh/public-banner.webp' />",
 +
 +    "<meta name=\"twitter:title\" content=\"Open SaaS\" />",

--- a/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/landing-page/components/Hero/Hero.tsx
 +++ opensaas-sh/app/src/landing-page/components/Hero/Hero.tsx
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,85 @@
 +import { ArrowRight } from 'lucide-react';
 +import { Link as ReactRouterLink } from 'react-router-dom';
 +import { useAuth } from 'wasp/client/auth';
@@ -24,9 +24,12 @@
 +                The <span className='italic'>free</span> SaaS template with{' '}
 +                <span className='text-gradient-primary font-black'>superpowers</span>
 +              </h1>
-+              <p className='mt-6 max-w-2xl text-lg leading-8 text-muted-foreground font-mono'>
-+                An open-source, feature-rich, full-stack React + NodeJS template that manages features for
-+                you.
++              <p className='mt-6 max-w-2xl text-md leading-8 text-muted-foreground font-mono'>
++                An open-source, feature-rich, full-stack React + NodeJS starter kit that manages boilerplate
++                for you. Built by
++                <a href='https://wasp.sh' className='group font-bold transition-all duration-300'>
++                  {' Wasp =}'}
++                </a>
 +              </p>
 +              <div className='mt-10 flex items-center justify-center md:justify-start gap-x-6'>
 +                <Button size='lg' variant='outline' asChild>

--- a/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
@@ -6,7 +6,7 @@
 +import { useAuth } from 'wasp/client/auth';
 +import { Link as WaspRouterLink, routes } from 'wasp/client/router';
 +import { Button } from '../../../components/ui/button';
-+import { DocsUrl } from '../../../shared/common';
++import { DocsUrl, WaspUrl } from '../../../shared/common';
 +import Orbit from './Orbit';
 +
 +export default function Hero() {
@@ -26,8 +26,8 @@
 +              </h1>
 +              <p className='mt-6 max-w-2xl text-md leading-8 text-muted-foreground font-mono'>
 +                An open-source, feature-rich, full-stack React + NodeJS starter kit that manages boilerplate
-+                for you. Built by
-+                <a href='https://wasp.sh' className='group font-bold transition-all duration-300'>
++                for you. Powered by
++                <a href={WaspUrl} className='group font-bold transition-all duration-300'>
 +                  {' Wasp =}'}
 +                </a>
 +              </p>

--- a/opensaas-sh/app_diff/src/landing-page/contentSections.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/contentSections.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/landing-page/contentSections.tsx
 +++ opensaas-sh/app/src/landing-page/contentSections.tsx
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,244 @@
 +import { routes } from 'wasp/client/router';
 +import type { NavigationItem } from '../client/components/NavBar/NavBar';
 +import blog from '../client/static/assets/blog.webp';
@@ -15,7 +15,7 @@
 +import scribeist from '../client/static/examples/scribeist.webp';
 +import searchcraft from '../client/static/examples/searchcraft.webp';
 +import logo from '../client/static/logo.webp';
-+import { BlogUrl, DocsUrl, GithubUrl } from '../shared/common';
++import { BlogUrl, DocsUrl, GithubUrl, WaspUrl } from '../shared/common';
 +import { GridFeature } from './components/FeaturesGrid';
 +
 +export const landingPageNavigationItems: NavigationItem[] = [
@@ -175,7 +175,6 @@
 +      "This is exactly the framework I've been dreaming of ever since I've been waiting to fully venture into the JS Backend Dev world. I believe Wasp will go above 50k stars this year. The documentation alone gives me the confidence that this is my permanent Nodejs framework and I'm staying with Wasp. Phenomenal work by the team...  Please keep up your amazing spirits. Thank you",
 +  },
 +];
-+
 +export const faqs = [
 +  {
 +    id: 1,
@@ -198,12 +197,10 @@
 +    { name: 'Blog', href: BlogUrl },
 +  ],
 +  company: [
-+    { name: 'About', href: 'https://wasp.sh' },
-+    { name: 'Privacy', href: '#' },
-+    { name: 'Terms of Service', href: '#' },
++    { name: 'Terms of Service', href: GithubUrl + '/blob/main/LICENSE' },
++    { name: 'Made by the Wasp team = }', href: WaspUrl },
 +  ],
 +};
-+
 +export const examples = [
 +  {
 +    name: 'Microinfluencers',

--- a/opensaas-sh/app_diff/src/shared/common.ts.diff
+++ b/opensaas-sh/app_diff/src/shared/common.ts.diff
@@ -1,6 +1,7 @@
 --- template/app/src/shared/common.ts
 +++ opensaas-sh/app/src/shared/common.ts
-@@ -1,2 +1,3 @@
+@@ -1,2 +1,4 @@
  export const DocsUrl = 'https://docs.opensaas.sh';
  export const BlogUrl = 'https://docs.opensaas.sh/blog';
 +export const GithubUrl = 'https://github.com/wasp-lang/opensaas';
++export const WaspUrl = 'https://wasp.sh';


### PR DESCRIPTION
Fixes #478 

Simple one that updates the Open Graph and Twitter meta tags to include 'Built by Wasp' in the description. Updated the Hero section description to clarify the project as a starter kit and added attribution to Wasp with a link.

<img width="902" height="439" alt="image" src="https://github.com/user-attachments/assets/4eff9074-e69e-4cdf-9c49-079b01dea473" />

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
