### PR TITLE
Account page improvements

### DIFF
--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -1,4 +1,5 @@
 import { getCustomerPortalUrl, useQuery } from 'wasp/client/operations';
+import { Link as WaspRouterLink, routes } from 'wasp/client/router';
 import type { User } from 'wasp/entities';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
@@ -83,6 +84,7 @@ function UserCurrentSubscriptionPlan({ user }: { user: User }) {
       <dd className='mt-1 text-sm text-foreground sm:col-span-1 sm:mt-0'>{subscriptionPlanMessage}</dd>
       <div className='mt-4 sm:mt-0 ml-auto'>
         <CustomerPortalButton />
+        <BuyMoreButton />
       </div>
     </>
   );
@@ -129,5 +131,18 @@ function CustomerPortalButton() {
         Manage Payment Details
       </Button>
     </a>
+  );
+}
+
+function BuyMoreButton() {
+  return (
+    <Button variant='link'>
+      <WaspRouterLink
+        to={routes.PricingPageRoute.to}
+        className='font-medium text-sm text-primary hover:text-primary/80 transition-colors duration-200'
+      >
+        Buy More/Upgrade
+      </WaspRouterLink>
+    </Button>
   );
 }

--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -1,10 +1,14 @@
 import { getCustomerPortalUrl, useQuery } from 'wasp/client/operations';
-import { Link as WaspRouterLink, routes } from 'wasp/client/router';
 import type { User } from 'wasp/entities';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Separator } from '../components/ui/separator';
-import { SubscriptionStatus, parsePaymentPlanId, prettyPaymentPlanName } from '../payment/plans';
+import {
+  PaymentPlanId,
+  SubscriptionStatus,
+  parsePaymentPlanId,
+  prettyPaymentPlanName,
+} from '../payment/plans';
 
 export default function AccountPage({ user }: { user: User }) {
   return (
@@ -40,12 +44,14 @@ export default function AccountPage({ user }: { user: User }) {
             <div className='py-4 px-6'>
               <div className='grid grid-cols-1 sm:grid-cols-3 sm:gap-4'>
                 <dt className='text-sm font-medium text-muted-foreground'>Your Plan</dt>
-                <UserCurrentPaymentPlan
-                  subscriptionStatus={user.subscriptionStatus as SubscriptionStatus}
-                  subscriptionPlan={user.subscriptionPlan}
-                  datePaid={user.datePaid}
-                  credits={user.credits}
-                />
+                <UserCurrentSubscriptionPlan user={user} />
+              </div>
+            </div>
+            <Separator />
+            <div className='py-4 px-6'>
+              <div className='grid grid-cols-1 sm:grid-cols-3 sm:gap-4'>
+                <dt className='text-sm font-medium text-muted-foreground'>Credits</dt>
+                <dd className='mt-1 text-sm text-foreground sm:col-span-2 sm:mt-0'>{user.credits}</dd>
               </div>
             </div>
             <Separator />
@@ -62,61 +68,39 @@ export default function AccountPage({ user }: { user: User }) {
   );
 }
 
-type UserCurrentPaymentPlanProps = {
-  subscriptionPlan: string | null;
-  subscriptionStatus: SubscriptionStatus | null;
-  datePaid: Date | null;
-  credits: number;
-};
-
-function UserCurrentPaymentPlan({
-  subscriptionPlan,
-  subscriptionStatus,
-  datePaid,
-  credits,
-}: UserCurrentPaymentPlanProps) {
-  if (subscriptionStatus && subscriptionPlan && datePaid) {
-    return (
-      <>
-        <dd className='mt-1 text-sm text-foreground sm:col-span-1 sm:mt-0'>
-          {getUserSubscriptionStatusDescription({ subscriptionPlan, subscriptionStatus, datePaid })}
-        </dd>
-        {subscriptionStatus !== SubscriptionStatus.Deleted ? <CustomerPortalButton /> : <BuyMoreButton />}
-      </>
+function UserCurrentSubscriptionPlan({ user }: { user: User }) {
+  let subscriptionPlanMessage = 'Free Plan';
+  if (!!user.subscriptionPlan && !!user.subscriptionStatus && !!user.datePaid) {
+    subscriptionPlanMessage = formatSubscriptionStatusMessage(
+      parsePaymentPlanId(user.subscriptionPlan),
+      user.datePaid,
+      user.subscriptionStatus as SubscriptionStatus
     );
   }
 
   return (
     <>
-      <dd className='mt-1 text-sm text-foreground sm:col-span-1 sm:mt-0'>Credits remaining: {credits}</dd>
-      <BuyMoreButton />
+      <dd className='mt-1 text-sm text-foreground sm:col-span-1 sm:mt-0'>{subscriptionPlanMessage}</dd>
+      <div className='mt-4 sm:mt-0 ml-auto'>
+        <CustomerPortalButton />
+      </div>
     </>
   );
 }
 
-function getUserSubscriptionStatusDescription({
-  subscriptionPlan,
-  subscriptionStatus,
-  datePaid,
-}: {
-  subscriptionPlan: string;
-  subscriptionStatus: SubscriptionStatus;
-  datePaid: Date;
-}) {
-  const planName = prettyPaymentPlanName(parsePaymentPlanId(subscriptionPlan));
-  const endOfBillingPeriod = prettyPrintEndOfBillingPeriod(datePaid);
-  return prettyPrintStatus(planName, subscriptionStatus, endOfBillingPeriod);
-}
-
-function prettyPrintStatus(
-  planName: string,
-  subscriptionStatus: SubscriptionStatus,
-  endOfBillingPeriod: string
+function formatSubscriptionStatusMessage(
+  subscriptionPlan: PaymentPlanId,
+  datePaid: Date,
+  subscriptionStatus: SubscriptionStatus
 ): string {
+  const paymentPlanName = prettyPaymentPlanName(subscriptionPlan);
+
   const statusToMessage: Record<SubscriptionStatus, string> = {
-    active: `${planName}`,
-    past_due: `Payment for your ${planName} plan is past due! Please update your subscription payment information.`,
-    cancel_at_period_end: `Your ${planName} plan subscription has been canceled, but remains active until the end of the current billing period${endOfBillingPeriod}`,
+    active: `${paymentPlanName}`,
+    past_due: `Payment for your ${paymentPlanName} plan is past due! Please update your subscription payment information.`,
+    cancel_at_period_end: `Your ${paymentPlanName} plan subscription has been canceled, but remains active until the end of the current billing period: ${prettyPrintEndOfBillingPeriod(
+      datePaid
+    )}`,
     deleted: `Your previous subscription has been canceled and is no longer active.`,
   };
   if (Object.keys(statusToMessage).includes(subscriptionStatus)) {
@@ -129,52 +113,21 @@ function prettyPrintStatus(
 function prettyPrintEndOfBillingPeriod(date: Date) {
   const oneMonthFromNow = new Date(date);
   oneMonthFromNow.setMonth(oneMonthFromNow.getMonth() + 1);
-  return ': ' + oneMonthFromNow.toLocaleDateString();
-}
-
-function BuyMoreButton() {
-  return (
-    <div className='ml-4 flex-shrink-0 sm:col-span-1 sm:mt-0'>
-      <WaspRouterLink
-        to={routes.PricingPageRoute.to}
-        className='font-medium text-sm text-primary hover:text-primary/80 transition-colors duration-200'
-      >
-        Buy More/Upgrade
-      </WaspRouterLink>
-    </div>
-  );
+  return oneMonthFromNow.toLocaleDateString();
 }
 
 function CustomerPortalButton() {
-  const {
-    data: customerPortalUrl,
-    isLoading: isCustomerPortalUrlLoading,
-    error: customerPortalUrlError,
-  } = useQuery(getCustomerPortalUrl);
+  const { data: customerPortalUrl, isLoading: isCustomerPortalUrlLoading } = useQuery(getCustomerPortalUrl);
 
-  const handleClick = () => {
-    if (customerPortalUrlError) {
-      console.error('Error fetching customer portal url');
-    }
-
-    if (customerPortalUrl) {
-      window.open(customerPortalUrl, '_blank');
-    } else {
-      console.error('Customer portal URL is not available');
-    }
-  };
+  if (!customerPortalUrl) {
+    return null;
+  }
 
   return (
-    <div className='ml-4 flex-shrink-0 sm:col-span-1 sm:mt-0'>
-      <Button
-        onClick={handleClick}
-        disabled={isCustomerPortalUrlLoading}
-        variant='outline'
-        size='sm'
-        className='font-medium text-sm'
-      >
-        Manage Subscription
+    <a href={customerPortalUrl} target='_blank' rel='noopener noreferrer'>
+      <Button disabled={isCustomerPortalUrlLoading} variant='link'>
+        Manage Payment Details
       </Button>
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
Always display both subscription plan and credits information. 
Fixes https://github.com/wasp-lang/open-saas/issues/503

Always display customer portal link button if possible.

Rename the "buy more/upgrade" button to "buy more credits" and move it to credits row. Display it only if no subscription.
Why? If we want to upgrade subscription we can always use the "manage payment details" button.
Only thing we need to navigate to pricing page for is to buy more credits.

