### PR TITLE
Git ignore `opensaas-sh/app/` directory

### DIFF
--- a/opensaas-sh/.gitignore
+++ b/opensaas-sh/.gitignore
@@ -1,3 +1,1 @@
-# We can't ignore `app/` because it messes up our patch/diff procedure (check
-# the README for more info on this)
-# app/
+app/

--- a/opensaas-sh/tools/dope.sh
+++ b/opensaas-sh/tools/dope.sh
@@ -140,7 +140,7 @@ recreate_derived_dir() {
 
   echo "DONE: generated ${DERIVED_DIR}/"
 
-  (cd "${DERIVED_DIR}" && git init -b main)
+  (cd "${DERIVED_DIR}" && git init -b main -q)
 
   if [ ${num_patches_failed} -gt 0 ]; then
     echo -e "${RED_COLOR}${num_patches_failed} patches failed, look into generated files for merge conflicts.${RESET_COLOR}"

--- a/opensaas-sh/tools/dope.sh
+++ b/opensaas-sh/tools/dope.sh
@@ -140,6 +140,8 @@ recreate_derived_dir() {
 
   echo "DONE: generated ${DERIVED_DIR}/"
 
+  (cd "${DERIVED_DIR}" && git init -b main)
+
   if [ ${num_patches_failed} -gt 0 ]; then
     echo -e "${RED_COLOR}${num_patches_failed} patches failed, look into generated files for merge conflicts.${RESET_COLOR}"
     exit 1


### PR DESCRIPTION
## Description

People who work on Open SaaS are often pained by `opensaas-sh/app/` folder being tracked.

By forcing the `opensaas-sh/app/` to be a separate git repository (via `git init`), we can:
1) Git ignore it
2) Have rest of diffing logic work (`git ls-files`) because there are no changes to git ignored files from the perspective of `opensaas-sh/app/`.
 
