### PR TITLE
Fix template e2e tests timing out

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   WASP_TELEMETRY_DISABLE: 1
-  WASP_VERSION: 0.18.0
+  WASP_VERSION: 0.18.1
 
 jobs:
   test:

--- a/template/e2e-tests/tests/demoAppTests.spec.ts
+++ b/template/e2e-tests/tests/demoAppTests.spec.ts
@@ -21,8 +21,8 @@ test.describe.configure({ mode: "serial" });
 test.beforeAll(async ({ browser }) => {
   page = await browser.newPage();
   testUser = createRandomUser();
-  await signUserUp({ page: page, user: testUser });
-  await logUserIn({ page: page, user: testUser });
+  await signUserUp({ page, user: testUser });
+  await logUserIn({ page, user: testUser });
 });
 
 test.afterAll(async () => {


### PR DESCRIPTION
Wasp v0.18.0 renders a blank page due to our deps issues.
Hence, locator can't find anything and times out.
