### PR TITLE
Fix ambiguous Tailwind class warning for delay-[0]

### DIFF
--- a/template/app/src/admin/layout/Header.tsx
+++ b/template/app/src/admin/layout/Header.tsx
@@ -27,7 +27,7 @@ const Header = (props: {
               <span className="du-block absolute right-0 h-full w-full">
                 <span
                   className={cn(
-                    "bg-foreground relative left-0 top-0 my-1 block h-0.5 w-0 rounded-sm delay-[0] duration-200 ease-in-out",
+                    "bg-foreground relative left-0 top-0 my-1 block h-0.5 w-0 rounded-sm delay-0 duration-200 ease-in-out",
                     {
                       "!w-full delay-300": !props.sidebarOpen,
                     },
@@ -55,7 +55,7 @@ const Header = (props: {
                   className={cn(
                     "bg-foreground absolute left-2.5 top-0 block h-full w-0.5 rounded-sm delay-300 duration-200 ease-in-out",
                     {
-                      "!h-0 !delay-[0]": !props.sidebarOpen,
+                      "!h-0 !delay-0": !props.sidebarOpen,
                     },
                   )}
                 ></span>


### PR DESCRIPTION
## Summary
- Resolves #556

Replaces `delay-[0]` with `delay-0` in the admin header component to fix the Tailwind warning about ambiguous classes.

The issue was that `delay-[0]` uses Tailwind's arbitrary value syntax (brackets), but `0` is ambiguous because it could be interpreted as `0ms`, `0s`, or other units. Tailwind v3.4+ warns about this. The fix is to use the standard `delay-0` class instead, which explicitly means `0ms` transition delay.

