### PR TITLE
Update GitHub authentication scope to read-only email access

### DIFF
--- a/template/app/src/auth/userSignupFields.ts
+++ b/template/app/src/auth/userSignupFields.ts
@@ -68,7 +68,7 @@ function getGithubEmailInfo(githubData: z.infer<typeof githubDataSchema>) {
 // instead of ["user"] and access args.profile.username instead
 export function getGitHubAuthConfig() {
   return {
-    scopes: ["user"],
+    scopes: ["user:email"],
   };
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/wasp-lang/open-saas/issues/593 reported by @Fryuni
Tightens the GitHub login scope to readonly email access for security reasons

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
