### PR TITLE
Set npm prefer-online for wasp CLI wrapper

### DIFF
--- a/tools/wasp
+++ b/tools/wasp
@@ -2,4 +2,4 @@
 
 # Just a wrapper to always use the latest Wasp CLI from main branch.
 
-npx -y https://pkg.pr.new/@wasp.sh/wasp-cli@main "$@"
+npm_config_prefer_online=true npx -y https://pkg.pr.new/@wasp.sh/wasp-cli@main "$@"


### PR DESCRIPTION
## Description

Npm could be picking up old versions of the `https://pkg.pr.new/@wasp.sh/wasp-cli@main` package if it was in the cache. Now we ask it to prefer checking online.

## Contributor Checklist

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any necessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any necessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).