### PR TITLE
Fix dark mode after Tailwind 4 upgrade

### DIFF
--- a/template/app/src/client/Main.css
+++ b/template/app/src/client/Main.css
@@ -1,12 +1,12 @@
 @import "tailwindcss" source("..");
 
-@plugin '@tailwindcss/forms';
-@plugin '@tailwindcss/typography';
-@plugin 'tailwindcss-animate';
+@plugin "@tailwindcss/forms";
+@plugin "@tailwindcss/typography";
+@plugin "tailwindcss-animate";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
-@theme {
+@theme inline {
   --color-current: currentColor;
   --color-transparent: transparent;
   --color-black-2: #010101;
@@ -98,7 +98,7 @@
   --z-index-99999: 99999;
   --z-index-999999: 999999;
 
-  --content-icon-copy: url('../images/icon/icon-copy-alt.svg');
+  --content-icon-copy: url("../images/icon/icon-copy-alt.svg");
 
   --transition-property-width: width;
   --transition-property-stroke: stroke;


### PR DESCRIPTION
- Fixes #607

## Summary
The main problem is that `@theme` by default tries to generate code into the classes directly, so indirections through CSS variables don't work. To fix it, you have to add the `inline` option so that theme is outputted itself and can follow CSS variables: https://tailwindcss.com/docs/theme#referencing-other-variables

Changes:
- Uses the dark mode selector as advised by Tailwind [(docs)](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually)
- Changes `@theme` to `@theme inline` for proper Tailwind 4 compatibility
- Normalizes quote style in CSS directives
