### PR TITLE
Add .npmrc with min-release-age to all packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Helps prevent supply chain attacks
+min-release-age=7

--- a/opensaas-sh/blog/.npmrc
+++ b/opensaas-sh/blog/.npmrc
@@ -1,0 +1,2 @@
+# Helps prevent supply chain attacks
+min-release-age=7

--- a/template/app/.npmrc
+++ b/template/app/.npmrc
@@ -1,0 +1,2 @@
+# Helps prevent supply chain attacks
+min-release-age=7

--- a/template/blog/.npmrc
+++ b/template/blog/.npmrc
@@ -1,0 +1,2 @@
+# Helps prevent supply chain attacks
+min-release-age=7

--- a/template/e2e-tests/.npmrc
+++ b/template/e2e-tests/.npmrc
@@ -1,0 +1,2 @@
+# Helps prevent supply chain attacks
+min-release-age=7


### PR DESCRIPTION
## Description

Adds an `.npmrc` file next to every `package.json` in the repo, setting `min-release-age=7`. This helps prevent supply chain attacks by ensuring npm only installs packages that have been published for at least 7 days.

## Contributor Checklist

- [x] **Update e2e tests**: `.npmrc` added to `/template/e2e-tests`.
- [ ] **Update demo app**: No app changes.
- [ ] **Update docs**: No doc changes needed.