### PR TITLE
fix: render backtick-enclosed text as inline code in roadmap titles

### DIFF
--- a/opensaas-sh/app_diff/src/landing-page/components/RoadmapEpicCard.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/RoadmapEpicCard.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/landing-page/components/RoadmapEpicCard.tsx
 +++ opensaas-sh/app/src/landing-page/components/RoadmapEpicCard.tsx
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,109 @@
 +import { Plus } from "lucide-react";
 +import { cn } from "../../client/utils";
 +import type { GithubEpic } from "../operations";
@@ -29,7 +29,7 @@
 +      )}
 +    >
 +      <h4 className="text-base font-semibold leading-tight text-gray-900 transition-opacity dark:text-white">
-+        {epic.name}
++        {renderTitle(epic.name)}
 +      </h4>
 +
 +      <div className="mt-auto pt-1">
@@ -93,3 +93,20 @@
 +      return "hover:border-gray-400 dark:hover:border-gray-600";
 +  }
 +};
++
++function renderTitle(text: string) {
++  const parts = text.split(/`([^`]+)`/);
++  if (parts.length === 1) return text;
++  return parts.map((part, i) =>
++    i % 2 === 1 ? (
++      <code
++        key={i}
++        className="rounded bg-gray-100 px-1 py-0.5 font-mono text-sm dark:bg-gray-800"
++      >
++        {part}
++      </code>
++    ) : (
++      <span key={i}>{part}</span>
++    ),
++  );
++}


### PR DESCRIPTION
Fixes #583

## Problem

GitHub project titles can contain backtick characters (e.g., `` `Demo App` ``). When rendered as plain text in the Roadmap section of the landing page, the backticks appeared as misaligned diacritics (the character "Ì") on top of adjacent letters instead of rendering as inline code.

## Solution

Added a `renderTitle` helper function in `RoadmapEpicCard.tsx` that:
1. Splits the title on backtick pairs using a regex
2. Renders backtick-enclosed substrings as `<code>` elements with a subtle gray background styling consistent with the existing design
3. Returns plain strings unchanged (when no backticks are present) for minimal overhead

The result is that a title like `` Improve GPT Wrapper `Demo App` `` now shows "Demo App" in an inline code style, matching the intended Markdown semantics of GitHub project titles.

## Testing

The fix is contained to the `renderTitle` helper in `RoadmapEpicCard.tsx`. The logic can be verified by checking that:
- Titles with no backticks are returned as plain strings (no change in rendering)
- Titles with backtick pairs have the enclosed content wrapped in styled `<code>` elements
- Partial/unmatched backticks (odd number) are left as-is by the regex split

The change is in the `app_diff` file which gets applied to produce the `opensaas-sh` app.