### PR TITLE
Make component exports consistent through project

### DIFF
--- a/opensaas-sh/app_diff/main.wasp.diff
+++ b/opensaas-sh/app_diff/main.wasp.diff
@@ -106,7 +106,7 @@
    },
  }
 @@ -105,6 +102,11 @@
-   component: import LandingPage from "@src/landing-page/LandingPage"
+   component: import { LandingPage } from "@src/landing-page/LandingPage"
  }
  
 +query getGithubRoadmap {
@@ -148,7 +148,7 @@
  
  //#region Analytics
 @@ -295,7 +308,6 @@
-   component: import AdminCalendar from "@src/admin/elements/calendar/CalendarPage"
+   component: import { CalendarPage } from "@src/admin/elements/calendar/CalendarPage"
  }
  
 -

--- a/opensaas-sh/app_diff/src/client/App.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/App.tsx.diff
@@ -7,7 +7,7 @@
  import { routes } from "wasp/client/router";
  import { Toaster } from "../client/components/ui/toaster";
 @@ -17,9 +17,7 @@
- export default function App() {
+ export function App() {
    const location = useLocation();
    const isMarketingPage = useMemo(() => {
 -    return (

--- a/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
@@ -11,8 +11,8 @@
 @@ -17,6 +18,7 @@
  import logo from "../../static/logo.webp";
  import { cn } from "../../utils";
- import DarkModeSwitcher from "../DarkModeSwitcher";
-+import RepoInfo from "../RepoInfo";
+ import { DarkModeSwitcher } from "../DarkModeSwitcher";
++import { RepoInfo } from "../RepoInfo";
  import { Announcement } from "./Announcement";
  
  export interface NavigationItem {

--- a/opensaas-sh/app_diff/src/client/components/RepoInfo.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/components/RepoInfo.tsx.diff
@@ -1,12 +1,12 @@
 --- template/app/src/client/components/RepoInfo.tsx
 +++ opensaas-sh/app/src/client/components/RepoInfo.tsx
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,47 @@
 +import { useEffect, useState } from "react";
 +import { FaGithub } from "react-icons/fa";
 +import { Button } from "../../client/components/ui/button";
 +import { formatNumber } from "../utils";
 +
-+const RepoInfo = () => {
++export const RepoInfo = () => {
 +  const [repoInfo, setRepoInfo] = useState<null | any>(null);
 +  const [isLoading, setIsLoading] = useState(true);
 +
@@ -48,4 +48,3 @@
 +  );
 +};
 +
-+export default RepoInfo;

--- a/opensaas-sh/app_diff/src/landing-page/LandingPage.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/LandingPage.tsx.diff
@@ -2,22 +2,22 @@
 +++ opensaas-sh/app/src/landing-page/LandingPage.tsx
 @@ -1,8 +1,10 @@
 +import { Admin, AIReady, Auth, Payments } from "./components/Examples";
- import ExamplesCarousel from "./components/ExamplesCarousel";
- import FAQ from "./components/FAQ";
- import FeaturesGrid from "./components/FeaturesGrid";
- import Footer from "./components/Footer";
- import Hero from "./components/Hero";
-+import Roadmap from "./components/Roadmap";
- import Testimonials from "./components/Testimonials";
+ import { ExamplesCarousel } from "./components/ExamplesCarousel";
+ import { FAQ } from "./components/FAQ";
+ import { FeaturesGrid } from "./components/FeaturesGrid";
+ import { Footer } from "./components/Footer";
+ import { Hero } from "./components/Hero";
++import { Roadmap } from "./components/Roadmap";
+ import { Testimonials } from "./components/Testimonials";
  import {
    examples,
 @@ -11,7 +13,6 @@
    footerNavigation,
    testimonials,
  } from "./contentSections";
--import AIReady from "./ExampleHighlightedFeature";
+-import { AIReady } from "./ExampleHighlightedFeature";
  
- export default function LandingPage() {
+ export function LandingPage() {
    return (
 @@ -20,7 +21,11 @@
          <Hero />

--- a/opensaas-sh/app_diff/src/landing-page/components/Examples/AIReady.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Examples/AIReady.tsx.diff
@@ -3,9 +3,9 @@
 @@ -0,0 +1,23 @@
 +import aiReadyDark from "../../../client/static/assets/aiready-dark.webp";
 +import aiReady from "../../../client/static/assets/aiready.webp";
-+import HighlightedFeature from "../HighlightedFeature";
++import { HighlightedFeature } from "../HighlightedFeature";
 +
-+export default function AIReady() {
++export function AIReady() {
 +  return (
 +    <HighlightedFeature
 +      name="AI Ready"

--- a/opensaas-sh/app_diff/src/landing-page/components/Examples/Admin.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Examples/Admin.tsx.diff
@@ -2,9 +2,9 @@
 +++ opensaas-sh/app/src/landing-page/components/Examples/Admin.tsx
 @@ -0,0 +1,20 @@
 +import admin from "../../../client/static/assets/admin.webp";
-+import HighlightedFeature from "../HighlightedFeature";
++import { HighlightedFeature } from "../HighlightedFeature";
 +
-+export default function Admin() {
++export function Admin() {
 +  return (
 +    <HighlightedFeature
 +      name="Admin Dashboard"

--- a/opensaas-sh/app_diff/src/landing-page/components/Examples/Auth.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Examples/Auth.tsx.diff
@@ -11,7 +11,7 @@
 +} from "../../../client/components/ui/card";
 +import { Input } from "../../../client/components/ui/input";
 +import { DocsUrl } from "../../../shared/common";
-+import HighlightedFeature from "../HighlightedFeature";
++import { HighlightedFeature } from "../HighlightedFeature";
 +
 +const Provider = {
 +  google: { displayName: "Google", icon: FaGoogle },
@@ -30,7 +30,7 @@
 +  provider: (typeof Provider)[AuthProvider],
 +])[];
 +
-+export default function Auth() {
++export function Auth() {
 +  const [selectedProviders, setSelectedProviders] = useState<
 +    readonly AuthProvider[]
 +  >(["google", "github"]);

--- a/opensaas-sh/app_diff/src/landing-page/components/Examples/Payments.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Examples/Payments.tsx.diff
@@ -2,9 +2,9 @@
 +++ opensaas-sh/app/src/landing-page/components/Examples/Payments.tsx
 @@ -0,0 +1,21 @@
 +import payments from "../../../client/static/assets/payments.webp";
-+import HighlightedFeature from "../HighlightedFeature";
++import { HighlightedFeature } from "../HighlightedFeature";
 +
-+export default function Payments() {
++export function Payments() {
 +  return (
 +    <HighlightedFeature
 +      name="Stripe / Polar.sh / Lemon Squeezy Integration"

--- a/opensaas-sh/app_diff/src/landing-page/components/Examples/index.ts.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Examples/index.ts.diff
@@ -1,7 +1,7 @@
 --- template/app/src/landing-page/components/Examples/index.ts
 +++ opensaas-sh/app/src/landing-page/components/Examples/index.ts
 @@ -0,0 +1,4 @@
-+export { default as Admin } from "./Admin";
-+export { default as AIReady } from "./AIReady";
-+export { default as Auth } from "./Auth";
-+export { default as Payments } from "./Payments";
++export { Admin } from "./Admin";
++export { AIReady } from "./AIReady";
++export { Auth } from "./Auth";
++export { Payments } from "./Payments";

--- a/opensaas-sh/app_diff/src/landing-page/components/FeaturesGrid.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/FeaturesGrid.tsx.diff
@@ -2,7 +2,7 @@
 +++ opensaas-sh/app/src/landing-page/components/FeaturesGrid.tsx
 @@ -9,13 +9,15 @@
  import { Feature } from "./Features";
- import SectionTitle from "./SectionTitle";
+ import { SectionTitle } from "./SectionTitle";
  
 -export interface GridFeature extends Omit<Feature, "icon"> {
 +export interface GridFeature extends Omit<Feature, "icon" | "name"> {
@@ -17,7 +17,7 @@
  }
  
  interface FeaturesGridProps {
-@@ -59,7 +61,8 @@
+@@ -62,7 +64,8 @@
    direction = "col",
    align = "center",
    size = "medium",
@@ -27,7 +27,7 @@
  }: GridFeature) {
    const gridFeatureSizeToClasses: Record<GridFeature["size"], string> = {
      small: "col-span-1",
-@@ -77,60 +80,98 @@
+@@ -80,60 +83,98 @@
      "col-reverse": "flex-col-reverse",
    };
  
@@ -155,7 +155,7 @@
        </CardContent>
      </Card>
    );
-@@ -141,7 +182,7 @@
+@@ -144,7 +185,7 @@
          href={href}
          target="_blank"
          rel="noopener noreferrer"

--- a/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Hero/Hero.tsx.diff
@@ -7,9 +7,9 @@
 +import { Link as WaspRouterLink, routes } from "wasp/client/router";
 +import { Button } from "../../../client/components/ui/button";
 +import { DocsUrl, WaspUrl } from "../../../shared/common";
-+import Orbit from "./Orbit";
++import { Orbit } from "./Orbit";
 +
-+export default function Hero() {
++export function Hero() {
 +  const { data: user } = useAuth();
 +
 +  return (

--- a/opensaas-sh/app_diff/src/landing-page/components/Hero/Orbit.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Hero/Orbit.tsx.diff
@@ -9,11 +9,11 @@
 +import tailwindLogoDark from "../../../client/static/logos/tailwind-dark.webp";
 +import tailwindLogo from "../../../client/static/logos/tailwind-light.webp";
 +import { cn } from "../../../client/utils";
-+import AstroLogo from "../../logos/AstroLogo";
-+import OpenAILogo from "../../logos/OpenAILogo";
-+import PrismaLogo from "../../logos/PrismaLogo";
-+import ReactLogo from "../../logos/ReactLogo";
-+import ShadCNLogo from "../../logos/ShadCNLogo";
++import { AstroLogo } from "../../logos/AstroLogo";
++import { OpenAILogo } from "../../logos/OpenAILogo";
++import { PrismaLogo } from "../../logos/PrismaLogo";
++import { ReactLogo } from "../../logos/ReactLogo";
++import { ShadCNLogo } from "../../logos/ShadCNLogo";
 +
 +interface LogoConfig {
 +  id: string;
@@ -198,7 +198,7 @@
 +  )`,
 +];
 +
-+export default function Orbit() {
++export function Orbit() {
 +  return (
 +    <div className="relative flex h-[500px] w-[500px] items-center justify-center">
 +      <style>{`

--- a/opensaas-sh/app_diff/src/landing-page/components/Hero/index.ts.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Hero/index.ts.diff
@@ -1,6 +1,4 @@
 --- template/app/src/landing-page/components/Hero/index.ts
 +++ opensaas-sh/app/src/landing-page/components/Hero/index.ts
-@@ -0,0 +1,3 @@
-+import Hero from "./Hero";
-+
-+export default Hero;
+@@ -0,0 +1 @@
++export { Hero } from "./Hero";

--- a/opensaas-sh/app_diff/src/landing-page/components/HighlightedFeature.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/HighlightedFeature.tsx.diff
@@ -18,7 +18,7 @@
 @@ -13,11 +16,14 @@
   * Shows text description on one side, and whatever component you want to show on the other side to demonstrate the functionality.
   */
- const HighlightedFeature = ({
+ export const HighlightedFeature = ({
 +  id,
    name,
    description,

--- a/opensaas-sh/app_diff/src/landing-page/components/Roadmap.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Roadmap.tsx.diff
@@ -8,7 +8,7 @@
 +import { getGithubRoadmap, useQuery } from "wasp/client/operations";
 +import { RoadmapStatusColumn } from "./RoadmapStatusColumn";
 +
-+export default function Roadmap() {
++export function Roadmap() {
 +  const { data: epics, isLoading, error } = useQuery(getGithubRoadmap);
 +
 +  if (isLoading) {

--- a/opensaas-sh/app_diff/src/landing-page/logos/PrismaLogo.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/logos/PrismaLogo.tsx.diff
@@ -1,7 +1,7 @@
 --- template/app/src/landing-page/logos/PrismaLogo.tsx
 +++ opensaas-sh/app/src/landing-page/logos/PrismaLogo.tsx
 @@ -1,8 +1,8 @@
- export default function PrismaLogo() {
+ export function PrismaLogo() {
    return (
      <svg
 -      width={48}

--- a/opensaas-sh/app_diff/src/landing-page/logos/ReactLogo.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/logos/ReactLogo.tsx.diff
@@ -1,7 +1,7 @@
 --- template/app/src/landing-page/logos/ReactLogo.tsx
 +++ opensaas-sh/app/src/landing-page/logos/ReactLogo.tsx
 @@ -0,0 +1,28 @@
-+export default function ReactLogo() {
++export function ReactLogo() {
 +  return (
 +    <svg
 +      width={32}

--- a/opensaas-sh/app_diff/src/landing-page/logos/SalesforceLogo.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/logos/SalesforceLogo.tsx.diff
@@ -1,10 +1,10 @@
 --- template/app/src/landing-page/logos/SalesforceLogo.tsx
 +++ opensaas-sh/app/src/landing-page/logos/SalesforceLogo.tsx
-@@ -1,27 +1,24 @@
--export default function SalesforceLogo() {
+@@ -1,27 +1,22 @@
+-export function SalesforceLogo() {
 +import React from "react";
 +
-+const SalesforceLogo: React.FC = () => {
++export const SalesforceLogo: React.FC = () => {
    return (
 -    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273 191">
 -      <defs>
@@ -47,5 +47,3 @@
    );
 -}
 +};
-+
-+export default SalesforceLogo;

--- a/opensaas-sh/app_diff/src/landing-page/logos/ShadCNLogo.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/logos/ShadCNLogo.tsx.diff
@@ -1,7 +1,7 @@
 --- template/app/src/landing-page/logos/ShadCNLogo.tsx
 +++ opensaas-sh/app/src/landing-page/logos/ShadCNLogo.tsx
 @@ -0,0 +1,34 @@
-+export default function ShadCNLogo() {
++export function ShadCNLogo() {
 +  return (
 +    <svg
 +      width={32}

--- a/opensaas-sh/blog/src/content/docs/guides/authorization.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authorization.md
@@ -43,7 +43,7 @@ If you want more fine-grained control over what users can access, there are two 
 ```tsx title="ExamplePage.tsx" "{ user }: { user: User }"
 import { type User } from "wasp/entities";
 
-export default function Example({ user }: { user: User }) {
+export function Example({ user }: { user: User }) {
 
   if (user.subscriptionStatus === 'past_due') {
     return (<span>Your subscription is past due. Please update your payment information.</span>)
@@ -63,7 +63,7 @@ export default function Example({ user }: { user: User }) {
 ```tsx title="ExamplePage.tsx" {1, 4}
 import { useAuth } from "wasp/client/auth";
 
-export default function ExampleHomePage() {
+export function ExampleHomePage() {
   const { data: user } = useAuth();
 
   return (

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -80,7 +80,7 @@ app OpenSaaS {
   },
 
   client: {
-    rootComponent: import App from "@src/client/App",
+    rootComponent: import { App } from "@src/client/App",
   },
 
   server: {
@@ -102,13 +102,13 @@ app OpenSaaS {
 
 route LandingPageRoute { path: "/", to: LandingPage }
 page LandingPage {
-  component: import LandingPage from "@src/landing-page/LandingPage"
+  component: import { LandingPage } from "@src/landing-page/LandingPage"
 }
 
 //#region Auth Pages
 route LoginRoute { path: "/login", to: LoginPage }
 page LoginPage {
-  component: import Login from "@src/auth/LoginPage"
+  component: import { Login } from "@src/auth/LoginPage"
 }
 
 route SignupRoute { path: "/signup", to: SignupPage }
@@ -136,7 +136,7 @@ page EmailVerificationPage {
 route AccountRoute { path: "/account", to: AccountPage }
 page AccountPage {
   authRequired: true,
-  component: import Account from "@src/user/AccountPage"
+  component: import { AccountPage } from "@src/user/AccountPage"
 }
 
 query getPaginatedUsers {
@@ -154,7 +154,7 @@ action updateIsUserAdminById {
 route DemoAppRoute { path: "/demo-app", to: DemoAppPage }
 page DemoAppPage {
   authRequired: true,
-  component: import DemoAppPage from "@src/demo-ai-app/DemoAppPage"
+  component: import { DemoAppPage } from "@src/demo-ai-app/DemoAppPage"
 }
 
 action generateGptResponse {
@@ -191,13 +191,13 @@ query getAllTasksByUser {
 //#region Payment
 route PricingPageRoute { path: "/pricing", to: PricingPage }
 page PricingPage {
-  component: import PricingPage from "@src/payment/PricingPage"
+  component: import { PricingPage } from "@src/payment/PricingPage"
 }
 
 route CheckoutResultRoute { path: "/checkout", to: CheckoutResultPage }
 page CheckoutResultPage {
   authRequired: true,
-  component: import CheckoutResultPage from "@src/payment/CheckoutResultPage"
+  component: import { CheckoutResultPage } from "@src/payment/CheckoutResultPage"
 }
 
 query getCustomerPortalUrl {
@@ -222,7 +222,7 @@ api paymentsWebhook {
 route FileUploadRoute { path: "/file-upload", to: FileUploadPage }
 page FileUploadPage {
   authRequired: true,
-  component: import FileUpload from "@src/file-upload/FileUploadPage"
+  component: import { FileUploadPage } from "@src/file-upload/FileUploadPage"
 }
 
 action createFileUploadUrl {
@@ -274,32 +274,32 @@ job dailyStatsJob {
 route AdminRoute { path: "/admin", to: AnalyticsDashboardPage }
 page AnalyticsDashboardPage {
   authRequired: true,
-  component: import AnalyticsDashboardPage from "@src/admin/dashboards/analytics/AnalyticsDashboardPage"
+  component: import { AnalyticsDashboardPage } from "@src/admin/dashboards/analytics/AnalyticsDashboardPage"
 }
 
 route AdminUsersRoute { path: "/admin/users", to: AdminUsersPage }
 page AdminUsersPage {
   authRequired: true,
-  component: import AdminUsers from "@src/admin/dashboards/users/UsersDashboardPage"
+  component: import { UsersDashboardPage } from "@src/admin/dashboards/users/UsersDashboardPage"
 }
 
 route AdminSettingsRoute { path: "/admin/settings", to: AdminSettingsPage }
 page AdminSettingsPage {
   authRequired: true,
-  component: import AdminSettings from "@src/admin/elements/settings/SettingsPage"
+  component: import { SettingsPage } from "@src/admin/elements/settings/SettingsPage"
 }
 
 route AdminCalendarRoute { path: "/admin/calendar", to: AdminCalendarPage }
 page AdminCalendarPage {
   authRequired: true,
-  component: import AdminCalendar from "@src/admin/elements/calendar/CalendarPage"
+  component: import { CalendarPage } from "@src/admin/elements/calendar/CalendarPage"
 }
 
 
 route AdminUIButtonsRoute { path: "/admin/ui/buttons", to: AdminUIButtonsPage }
 page AdminUIButtonsPage {
   authRequired: true,
-  component: import AdminUI from "@src/admin/elements/ui-elements/ButtonsPage"
+  component: import { ButtonsPage } from "@src/admin/elements/ui-elements/ButtonsPage"
 }
 
 route NotFoundRoute { path: "*", to: NotFoundPage }
@@ -315,6 +315,6 @@ page NotFoundPage {
 route AdminMessagesRoute { path: "/admin/messages", to: AdminMessagesPage }
 page AdminMessagesPage {
   authRequired: true,
-  component: import AdminMessages from "@src/admin/dashboards/messages/MessagesPage"
+  component: import { AdminMessages } from "@src/admin/dashboards/messages/MessagesPage"
 }
 //#endregion

--- a/template/app/src/admin/dashboards/analytics/AnalyticsDashboardPage.tsx
+++ b/template/app/src/admin/dashboards/analytics/AnalyticsDashboardPage.tsx
@@ -1,15 +1,15 @@
 import { type AuthUser } from "wasp/auth";
 import { getDailyStats, useQuery } from "wasp/client/operations";
 import { cn } from "../../../client/utils";
-import DefaultLayout from "../../layout/DefaultLayout";
-import RevenueAndProfitChart from "./RevenueAndProfitChart";
-import SourcesTable from "./SourcesTable";
-import TotalPageViewsCard from "./TotalPageViewsCard";
-import TotalPayingUsersCard from "./TotalPayingUsersCard";
-import TotalRevenueCard from "./TotalRevenueCard";
-import TotalSignupsCard from "./TotalSignupsCard";
+import { DefaultLayout } from "../../layout/DefaultLayout";
+import { RevenueAndProfitChart } from "./RevenueAndProfitChart";
+import { SourcesTable } from "./SourcesTable";
+import { TotalPageViewsCard } from "./TotalPageViewsCard";
+import { TotalPayingUsersCard } from "./TotalPayingUsersCard";
+import { TotalRevenueCard } from "./TotalRevenueCard";
+import { TotalSignupsCard } from "./TotalSignupsCard";
 
-const Dashboard = ({ user }: { user: AuthUser }) => {
+export const AnalyticsDashboardPage = ({ user }: { user: AuthUser }) => {
   const { data: stats, isLoading, error } = useQuery(getDailyStats);
 
   if (error) {
@@ -85,5 +85,3 @@ const Dashboard = ({ user }: { user: AuthUser }) => {
     </DefaultLayout>
   );
 };
-
-export default Dashboard;

--- a/template/app/src/admin/dashboards/analytics/RevenueAndProfitChart.tsx
+++ b/template/app/src/admin/dashboards/analytics/RevenueAndProfitChart.tsx
@@ -109,7 +109,7 @@ interface ChartOneState {
   }[];
 }
 
-const RevenueAndProfitChart = ({ weeklyStats }: DailyStatsProps) => {
+export const RevenueAndProfitChart = ({ weeklyStats }: DailyStatsProps) => {
   const dailyRevenueArray = useMemo(() => {
     if (!!weeklyStats && weeklyStats?.length > 0) {
       const sortedWeeks = weeklyStats?.sort((a, b) => {
@@ -256,5 +256,3 @@ const RevenueAndProfitChart = ({ weeklyStats }: DailyStatsProps) => {
     </div>
   );
 };
-
-export default RevenueAndProfitChart;

--- a/template/app/src/admin/dashboards/analytics/SourcesTable.tsx
+++ b/template/app/src/admin/dashboards/analytics/SourcesTable.tsx
@@ -1,6 +1,6 @@
 import { type PageViewSource } from "wasp/entities";
 
-const SourcesTable = ({
+export const SourcesTable = ({
   sources,
 }: {
   sources: PageViewSource[] | undefined;
@@ -58,5 +58,3 @@ const SourcesTable = ({
     </div>
   );
 };
-
-export default SourcesTable;

--- a/template/app/src/admin/dashboards/analytics/TotalPageViewsCard.tsx
+++ b/template/app/src/admin/dashboards/analytics/TotalPageViewsCard.tsx
@@ -11,7 +11,7 @@ type PageViewsStats = {
   prevDayViewsChangePercent: string | undefined;
 };
 
-const TotalPageViewsCard = ({
+export const TotalPageViewsCard = ({
   totalPageViews,
   prevDayViewsChangePercent,
 }: PageViewsStats) => {
@@ -64,5 +64,3 @@ const TotalPageViewsCard = ({
     </Card>
   );
 };
-
-export default TotalPageViewsCard;

--- a/template/app/src/admin/dashboards/analytics/TotalPayingUsersCard.tsx
+++ b/template/app/src/admin/dashboards/analytics/TotalPayingUsersCard.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../../client/components/ui/card";
 import { cn } from "../../../client/utils";
 
-const TotalPayingUsersCard = ({ dailyStats, isLoading }: DailyStatsProps) => {
+export const TotalPayingUsersCard = ({
+  dailyStats,
+  isLoading,
+}: DailyStatsProps) => {
   const isDeltaPositive = useMemo(() => {
     return !!dailyStats?.paidUserDelta && dailyStats?.paidUserDelta > 0;
   }, [dailyStats]);
@@ -48,5 +51,3 @@ const TotalPayingUsersCard = ({ dailyStats, isLoading }: DailyStatsProps) => {
     </Card>
   );
 };
-
-export default TotalPayingUsersCard;

--- a/template/app/src/admin/dashboards/analytics/TotalRevenueCard.tsx
+++ b/template/app/src/admin/dashboards/analytics/TotalRevenueCard.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../client/components/ui/card";
 import { cn } from "../../../client/utils";
 
-const TotalRevenueCard = ({
+export const TotalRevenueCard = ({
   dailyStats,
   weeklyStats,
   isLoading,
@@ -77,5 +77,3 @@ const TotalRevenueCard = ({
     </Card>
   );
 };
-
-export default TotalRevenueCard;

--- a/template/app/src/admin/dashboards/analytics/TotalSignupsCard.tsx
+++ b/template/app/src/admin/dashboards/analytics/TotalSignupsCard.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../../client/components/ui/card";
 import { cn } from "../../../client/utils";
 
-const TotalSignupsCard = ({ dailyStats, isLoading }: DailyStatsProps) => {
+export const TotalSignupsCard = ({
+  dailyStats,
+  isLoading,
+}: DailyStatsProps) => {
   const isDeltaPositive = useMemo(() => {
     return !!dailyStats?.userDelta && dailyStats.userDelta > 0;
   }, [dailyStats]);
@@ -46,5 +49,3 @@ const TotalSignupsCard = ({ dailyStats, isLoading }: DailyStatsProps) => {
     </Card>
   );
 };
-
-export default TotalSignupsCard;

--- a/template/app/src/admin/dashboards/messages/MessageButton.tsx
+++ b/template/app/src/admin/dashboards/messages/MessageButton.tsx
@@ -1,7 +1,7 @@
 import { MessageCircleMore } from "lucide-react";
 import { Link as WaspRouterLink, routes } from "wasp/client/router";
 
-const MessageButton = () => {
+export const MessageButton = () => {
   return (
     <li
       className="relative"
@@ -21,5 +21,3 @@ const MessageButton = () => {
     </li>
   );
 };
-
-export default MessageButton;

--- a/template/app/src/admin/dashboards/messages/MessagesPage.tsx
+++ b/template/app/src/admin/dashboards/messages/MessagesPage.tsx
@@ -1,13 +1,11 @@
 // TODO: Add messages page
 import type { AuthUser } from "wasp/auth";
-import DefaultLayout from "../../layout/DefaultLayout";
+import { DefaultLayout } from "../../layout/DefaultLayout";
 
-function AdminMessages({ user }: { user: AuthUser }) {
+export function AdminMessages({ user }: { user: AuthUser }) {
   return (
     <DefaultLayout user={user}>
       <div>This page is under construction 🚧</div>
     </DefaultLayout>
   );
 }
-
-export default AdminMessages;

--- a/template/app/src/admin/dashboards/users/DropdownEditDelete.tsx
+++ b/template/app/src/admin/dashboards/users/DropdownEditDelete.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from "../../../client/components/ui/dropdown-menu";
 
-const DropdownEditDelete = () => {
+export const DropdownEditDelete = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -27,5 +27,3 @@ const DropdownEditDelete = () => {
     </DropdownMenu>
   );
 };
-
-export default DropdownEditDelete;

--- a/template/app/src/admin/dashboards/users/UsersDashboardPage.tsx
+++ b/template/app/src/admin/dashboards/users/UsersDashboardPage.tsx
@@ -1,9 +1,9 @@
 import { type AuthUser } from "wasp/auth";
-import Breadcrumb from "../../layout/Breadcrumb";
-import DefaultLayout from "../../layout/DefaultLayout";
-import UsersTable from "./UsersTable";
+import { Breadcrumb } from "../../layout/Breadcrumb";
+import { DefaultLayout } from "../../layout/DefaultLayout";
+import { UsersTable } from "./UsersTable";
 
-const Users = ({ user }: { user: AuthUser }) => {
+export const UsersDashboardPage = ({ user }: { user: AuthUser }) => {
   return (
     <DefaultLayout user={user}>
       <Breadcrumb pageName="Users" />
@@ -13,5 +13,3 @@ const Users = ({ user }: { user: AuthUser }) => {
     </DefaultLayout>
   );
 };
-
-export default Users;

--- a/template/app/src/admin/dashboards/users/UsersTable.tsx
+++ b/template/app/src/admin/dashboards/users/UsersTable.tsx
@@ -19,10 +19,10 @@ import {
   SelectValue,
 } from "../../../client/components/ui/select";
 import { Switch } from "../../../client/components/ui/switch";
-import useDebounce from "../../../client/hooks/useDebounce";
+import { useDebounce } from "../../../client/hooks/useDebounce";
 import { SubscriptionStatus } from "../../../payment/plans";
-import LoadingSpinner from "../../layout/LoadingSpinner";
-import DropdownEditDelete from "./DropdownEditDelete";
+import { LoadingSpinner } from "../../layout/LoadingSpinner";
+import { DropdownEditDelete } from "./DropdownEditDelete";
 
 function AdminSwitch({ id, isAdmin }: Pick<User, "id" | "isAdmin">) {
   const { data: currentUser } = useAuth();
@@ -39,7 +39,7 @@ function AdminSwitch({ id, isAdmin }: Pick<User, "id" | "isAdmin">) {
   );
 }
 
-const UsersTable = () => {
+export const UsersTable = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [emailFilter, setEmailFilter] = useState<string | undefined>(undefined);
   const [isAdminFilter, setIsAdminFilter] = useState<boolean | undefined>(
@@ -320,5 +320,3 @@ const UsersTable = () => {
     </div>
   );
 };
-
-export default UsersTable;

--- a/template/app/src/admin/elements/calendar/CalendarPage.tsx
+++ b/template/app/src/admin/elements/calendar/CalendarPage.tsx
@@ -1,8 +1,8 @@
 import { type AuthUser } from "wasp/auth";
-import Breadcrumb from "../../layout/Breadcrumb";
-import DefaultLayout from "../../layout/DefaultLayout";
+import { Breadcrumb } from "../../layout/Breadcrumb";
+import { DefaultLayout } from "../../layout/DefaultLayout";
 
-const Calendar = ({ user }: { user: AuthUser }) => {
+export const CalendarPage = ({ user }: { user: AuthUser }) => {
   return (
     <DefaultLayout user={user}>
       <Breadcrumb pageName="Calendar" />
@@ -195,5 +195,3 @@ const Calendar = ({ user }: { user: AuthUser }) => {
     </DefaultLayout>
   );
 };
-
-export default Calendar;

--- a/template/app/src/admin/elements/settings/SettingsPage.tsx
+++ b/template/app/src/admin/elements/settings/SettingsPage.tsx
@@ -11,10 +11,10 @@ import {
 import { Input } from "../../../client/components/ui/input";
 import { Label } from "../../../client/components/ui/label";
 import { Textarea } from "../../../client/components/ui/textarea";
-import Breadcrumb from "../../layout/Breadcrumb";
-import DefaultLayout from "../../layout/DefaultLayout";
+import { Breadcrumb } from "../../layout/Breadcrumb";
+import { DefaultLayout } from "../../layout/DefaultLayout";
 
-const SettingsPage = ({ user }: { user: AuthUser }) => {
+export const SettingsPage = ({ user }: { user: AuthUser }) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     // TODO implement
     event.preventDefault();
@@ -201,5 +201,3 @@ const SettingsPage = ({ user }: { user: AuthUser }) => {
     </DefaultLayout>
   );
 };
-
-export default SettingsPage;

--- a/template/app/src/admin/elements/ui-elements/ButtonsPage.tsx
+++ b/template/app/src/admin/elements/ui-elements/ButtonsPage.tsx
@@ -1,10 +1,10 @@
 import { Heart, Plus, Trash2 } from "lucide-react";
 import { type AuthUser } from "wasp/auth";
 import { Button } from "../../../client/components/ui/button";
-import Breadcrumb from "../../layout/Breadcrumb";
-import DefaultLayout from "../../layout/DefaultLayout";
+import { Breadcrumb } from "../../layout/Breadcrumb";
+import { DefaultLayout } from "../../layout/DefaultLayout";
 
-const Buttons = ({ user }: { user: AuthUser }) => {
+export const ButtonsPage = ({ user }: { user: AuthUser }) => {
   return (
     <DefaultLayout user={user}>
       <Breadcrumb pageName="Buttons" />
@@ -71,5 +71,3 @@ const Buttons = ({ user }: { user: AuthUser }) => {
     </DefaultLayout>
   );
 };
-
-export default Buttons;

--- a/template/app/src/admin/layout/Breadcrumb.tsx
+++ b/template/app/src/admin/layout/Breadcrumb.tsx
@@ -2,7 +2,7 @@ import { Link as WaspRouterLink, routes } from "wasp/client/router";
 interface BreadcrumbProps {
   pageName: string;
 }
-const Breadcrumb = ({ pageName }: BreadcrumbProps) => {
+export const Breadcrumb = ({ pageName }: BreadcrumbProps) => {
   return (
     <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <h2 className="text-title-md2 text-foreground font-semibold">
@@ -21,5 +21,3 @@ const Breadcrumb = ({ pageName }: BreadcrumbProps) => {
     </div>
   );
 };
-
-export default Breadcrumb;

--- a/template/app/src/admin/layout/DefaultLayout.tsx
+++ b/template/app/src/admin/layout/DefaultLayout.tsx
@@ -1,15 +1,15 @@
 import { FC, ReactNode, useState } from "react";
 import { Navigate } from "react-router";
 import { type AuthUser } from "wasp/auth";
-import Header from "./Header";
-import Sidebar from "./Sidebar";
+import { Header } from "./Header";
+import { Sidebar } from "./Sidebar";
 
 interface Props {
   user: AuthUser;
   children?: ReactNode;
 }
 
-const DefaultLayout: FC<Props> = ({ children, user }) => {
+export const DefaultLayout: FC<Props> = ({ children, user }) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   if (!user.isAdmin) {
@@ -36,5 +36,3 @@ const DefaultLayout: FC<Props> = ({ children, user }) => {
     </div>
   );
 };
-
-export default DefaultLayout;

--- a/template/app/src/admin/layout/Header.tsx
+++ b/template/app/src/admin/layout/Header.tsx
@@ -1,10 +1,10 @@
 import { type AuthUser } from "wasp/auth";
-import DarkModeSwitcher from "../../client/components/DarkModeSwitcher";
+import { DarkModeSwitcher } from "../../client/components/DarkModeSwitcher";
 import { cn } from "../../client/utils";
 import { UserDropdown } from "../../user/UserDropdown";
-import MessageButton from "../dashboards/messages/MessageButton";
+import { MessageButton } from "../dashboards/messages/MessageButton";
 
-const Header = (props: {
+export const Header = (props: {
   sidebarOpen: string | boolean | undefined;
   setSidebarOpen: (arg0: boolean) => void;
   user: AuthUser;
@@ -93,5 +93,3 @@ const Header = (props: {
     </header>
   );
 };
-
-export default Header;

--- a/template/app/src/admin/layout/LoadingSpinner.tsx
+++ b/template/app/src/admin/layout/LoadingSpinner.tsx
@@ -1,9 +1,7 @@
-const LoadingSpinner = () => {
+export const LoadingSpinner = () => {
   return (
     <div className="flex items-center justify-center py-10">
       <div className="border-primary h-16 w-16 animate-spin rounded-full border-4 border-solid border-t-transparent"></div>
     </div>
   );
 };
-
-export default LoadingSpinner;

--- a/template/app/src/admin/layout/Sidebar.tsx
+++ b/template/app/src/admin/layout/Sidebar.tsx
@@ -12,14 +12,14 @@ import React, { useEffect, useRef, useState } from "react";
 import { NavLink, useLocation } from "react-router";
 import Logo from "../../client/static/logo.webp";
 import { cn } from "../../client/utils";
-import SidebarLinkGroup from "./SidebarLinkGroup";
+import { SidebarLinkGroup } from "./SidebarLinkGroup";
 
 interface SidebarProps {
   sidebarOpen: boolean;
   setSidebarOpen: (arg: boolean) => void;
 }
 
-const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
+export const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
   const location = useLocation();
   const { pathname } = location;
 
@@ -259,5 +259,3 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
     </aside>
   );
 };
-
-export default Sidebar;

--- a/template/app/src/admin/layout/SidebarLinkGroup.tsx
+++ b/template/app/src/admin/layout/SidebarLinkGroup.tsx
@@ -5,7 +5,7 @@ interface SidebarLinkGroupProps {
   activeCondition: boolean;
 }
 
-const SidebarLinkGroup = ({
+export const SidebarLinkGroup = ({
   children,
   activeCondition,
 }: SidebarLinkGroupProps) => {
@@ -17,5 +17,3 @@ const SidebarLinkGroup = ({
 
   return <li>{children(handleClick, open)}</li>;
 };
-
-export default SidebarLinkGroup;

--- a/template/app/src/auth/LoginPage.tsx
+++ b/template/app/src/auth/LoginPage.tsx
@@ -3,7 +3,7 @@ import { Link as WaspRouterLink, routes } from "wasp/client/router";
 import { AuthPageLayout } from "./AuthPageLayout";
 import { useRedirectIfLoggedIn } from "./hooks/useRedirectIfLoggedIn";
 
-export default function Login() {
+export function Login() {
   useRedirectIfLoggedIn();
 
   return (

--- a/template/app/src/client/App.tsx
+++ b/template/app/src/client/App.tsx
@@ -3,18 +3,18 @@ import { Outlet, useLocation } from "react-router";
 import { routes } from "wasp/client/router";
 import { Toaster } from "../client/components/ui/toaster";
 import "./Main.css";
-import NavBar from "./components/NavBar/NavBar";
+import { NavBar } from "./components/NavBar/NavBar";
 import {
   demoNavigationitems,
   marketingNavigationItems,
 } from "./components/NavBar/constants";
-import CookieConsentBanner from "./components/cookie-consent/Banner";
+import { CookieConsentBanner } from "./components/cookie-consent/Banner";
 
 /**
  * use this component to wrap all child components
  * this is useful for templates, themes, and context
  */
-export default function App() {
+export function App() {
   const location = useLocation();
   const isMarketingPage = useMemo(() => {
     return (

--- a/template/app/src/client/components/DarkModeSwitcher.tsx
+++ b/template/app/src/client/components/DarkModeSwitcher.tsx
@@ -1,9 +1,9 @@
 import { Moon, Sun } from "lucide-react";
 import { Label } from "../../client/components/ui/label";
-import useColorMode from "../hooks/useColorMode";
+import { useColorMode } from "../hooks/useColorMode";
 import { cn } from "../utils";
 
-const DarkModeSwitcher = () => {
+export const DarkModeSwitcher = () => {
   const [colorMode, setColorMode] = useColorMode();
   const isInLightMode = colorMode === "light";
 
@@ -56,5 +56,3 @@ function ModeIcon({ isInLightMode }: { isInLightMode: boolean }) {
     </>
   );
 }
-
-export default DarkModeSwitcher;

--- a/template/app/src/client/components/NavBar/NavBar.tsx
+++ b/template/app/src/client/components/NavBar/NavBar.tsx
@@ -16,7 +16,7 @@ import { UserMenuItems } from "../../../user/UserMenuItems";
 import { useIsLandingPage } from "../../hooks/useIsLandingPage";
 import logo from "../../static/logo.webp";
 import { cn } from "../../utils";
-import DarkModeSwitcher from "../DarkModeSwitcher";
+import { DarkModeSwitcher } from "../DarkModeSwitcher";
 import { Announcement } from "./Announcement";
 
 export interface NavigationItem {
@@ -24,7 +24,7 @@ export interface NavigationItem {
   to: string;
 }
 
-export default function NavBar({
+export function NavBar({
   navigationItems,
 }: {
   navigationItems: NavigationItem[];

--- a/template/app/src/client/components/cookie-consent/Banner.tsx
+++ b/template/app/src/client/components/cookie-consent/Banner.tsx
@@ -1,19 +1,17 @@
 import { useEffect } from "react";
 import * as CookieConsent from "vanilla-cookieconsent";
 import "vanilla-cookieconsent/dist/cookieconsent.css";
-import getConfig from "./Config";
+import { getConfig } from "./Config";
 
 /**
  * NOTE: if you do not want to use the cookie consent banner, you should
  * run `npm uninstall vanilla-cookieconsent`, and delete this component, its config file,
  * as well as its import in src/client/App.tsx .
  */
-const CookieConsentBanner = () => {
+export const CookieConsentBanner = () => {
   useEffect(() => {
     CookieConsent.run(getConfig());
   }, []);
 
   return <div id="cookieconsent"></div>;
 };
-
-export default CookieConsentBanner;

--- a/template/app/src/client/components/cookie-consent/Config.ts
+++ b/template/app/src/client/components/cookie-consent/Config.ts
@@ -6,7 +6,7 @@ declare global {
   }
 }
 
-const getConfig = () => {
+export const getConfig = () => {
   // See https://cookieconsent.orestbida.com/reference/configuration-reference.html for configuration options.
   const config: CookieConsentConfig = {
     // Default configuration for the modal.
@@ -119,5 +119,3 @@ const getConfig = () => {
 
   return config;
 };
-
-export default getConfig;

--- a/template/app/src/client/hooks/useColorMode.ts
+++ b/template/app/src/client/hooks/useColorMode.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
-import useLocalStorage from "./useLocalStorage";
+import { useLocalStorage } from "./useLocalStorage";
 
-export default function useColorMode() {
+export function useColorMode() {
   const [colorMode, setColorMode] = useLocalStorage("color-theme", "light");
 
   useEffect(() => {

--- a/template/app/src/client/hooks/useDebounce.ts
+++ b/template/app/src/client/hooks/useDebounce.ts
@@ -11,4 +11,3 @@ export function useDebounce<T>(value: T, delay: number): T {
 
   return debouncedValue;
 }
-

--- a/template/app/src/client/hooks/useDebounce.ts
+++ b/template/app/src/client/hooks/useDebounce.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function useDebounce<T>(value: T, delay: number): T {
+export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
@@ -12,4 +12,3 @@ function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
-export default useDebounce;

--- a/template/app/src/client/hooks/useLocalStorage.ts
+++ b/template/app/src/client/hooks/useLocalStorage.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 type SetValue<T> = T | ((val: T) => T);
 
-function useLocalStorage<T>(
+export function useLocalStorage<T>(
   key: string,
   initialValue: T,
 ): [T, (value: SetValue<T>) => void] {
@@ -44,4 +44,3 @@ function useLocalStorage<T>(
   return [storedValue, setStoredValue];
 }
 
-export default useLocalStorage;

--- a/template/app/src/client/hooks/useLocalStorage.ts
+++ b/template/app/src/client/hooks/useLocalStorage.ts
@@ -43,4 +43,3 @@ export function useLocalStorage<T>(
 
   return [storedValue, setStoredValue];
 }
-

--- a/template/app/src/demo-ai-app/DemoAppPage.tsx
+++ b/template/app/src/demo-ai-app/DemoAppPage.tsx
@@ -32,7 +32,7 @@ import type {
   TaskPriority,
 } from "./schedule";
 
-export default function DemoAppPage() {
+export function DemoAppPage() {
   return (
     <div className="py-10 lg:mt-10">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/template/app/src/file-upload/FileUploadPage.tsx
+++ b/template/app/src/file-upload/FileUploadPage.tsx
@@ -29,7 +29,7 @@ import { cn } from "../client/utils";
 import { uploadFileWithProgress, validateFile } from "./fileUploading";
 import { ALLOWED_FILE_TYPES } from "./validation";
 
-export default function FileUploadPage() {
+export function FileUploadPage() {
   const [fileKeyForS3, setFileKeyForS3] = useState<File["s3Key"]>("");
   const [uploadProgressPercent, setUploadProgressPercent] = useState<number>(0);
   const [fileToDelete, setFileToDelete] = useState<Pick<

--- a/template/app/src/landing-page/ExampleHighlightedFeature.tsx
+++ b/template/app/src/landing-page/ExampleHighlightedFeature.tsx
@@ -1,8 +1,8 @@
 import aiReadyDark from "../client/static/assets/aiready-dark.webp";
 import aiReady from "../client/static/assets/aiready.webp";
-import HighlightedFeature from "./components/HighlightedFeature";
+import { HighlightedFeature } from "./components/HighlightedFeature";
 
-export default function AIReady() {
+export function AIReady() {
   return (
     <HighlightedFeature
       name="Example Feature Highlight"

--- a/template/app/src/landing-page/LandingPage.tsx
+++ b/template/app/src/landing-page/LandingPage.tsx
@@ -1,9 +1,9 @@
-import ExamplesCarousel from "./components/ExamplesCarousel";
-import FAQ from "./components/FAQ";
-import FeaturesGrid from "./components/FeaturesGrid";
-import Footer from "./components/Footer";
-import Hero from "./components/Hero";
-import Testimonials from "./components/Testimonials";
+import { ExamplesCarousel } from "./components/ExamplesCarousel";
+import { FAQ } from "./components/FAQ";
+import { FeaturesGrid } from "./components/FeaturesGrid";
+import { Footer } from "./components/Footer";
+import { Hero } from "./components/Hero";
+import { Testimonials } from "./components/Testimonials";
 import {
   examples,
   faqs,
@@ -11,9 +11,9 @@ import {
   footerNavigation,
   testimonials,
 } from "./contentSections";
-import AIReady from "./ExampleHighlightedFeature";
+import { AIReady } from "./ExampleHighlightedFeature";
 
-export default function LandingPage() {
+export function LandingPage() {
   return (
     <div className="bg-background text-foreground">
       <main className="isolate">

--- a/template/app/src/landing-page/components/Clients.tsx
+++ b/template/app/src/landing-page/components/Clients.tsx
@@ -1,7 +1,7 @@
-import AstroLogo from "../logos/AstroLogo";
-import OpenAILogo from "../logos/OpenAILogo";
-import PrismaLogo from "../logos/PrismaLogo";
-import SalesforceLogo from "../logos/SalesforceLogo";
+import { AstroLogo } from "../logos/AstroLogo";
+import { OpenAILogo } from "../logos/OpenAILogo";
+import { PrismaLogo } from "../logos/PrismaLogo";
+import { SalesforceLogo } from "../logos/SalesforceLogo";
 
 const LOGOS = [
   { id: "salesforce", element: <SalesforceLogo /> },
@@ -10,7 +10,7 @@ const LOGOS = [
   { id: "openai", element: <OpenAILogo /> },
 ];
 
-export default function Clients() {
+export function Clients() {
   return (
     <div className="items-between mx-auto mt-12 flex max-w-7xl flex-col gap-y-6 px-6 lg:px-8">
       <h2 className="text-muted-foreground mb-6 text-center font-semibold tracking-wide">

--- a/template/app/src/landing-page/components/ExamplesCarousel.tsx
+++ b/template/app/src/landing-page/components/ExamplesCarousel.tsx
@@ -11,7 +11,7 @@ interface ExampleApp {
   href: string;
 }
 
-const ExamplesCarousel = ({ examples }: { examples: ExampleApp[] }) => {
+export const ExamplesCarousel = ({ examples }: { examples: ExampleApp[] }) => {
   const [currentExample, setCurrentExample] = useState(0);
   const [isInView, setIsInView] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -173,5 +173,3 @@ const ExampleCard = forwardRef<HTMLDivElement, ExampleCardProps>(
 );
 
 ExampleCard.displayName = "ExampleCard";
-
-export default ExamplesCarousel;

--- a/template/app/src/landing-page/components/FAQ.tsx
+++ b/template/app/src/landing-page/components/FAQ.tsx
@@ -12,7 +12,7 @@ interface FAQ {
   href?: string;
 }
 
-export default function FAQ({ faqs }: { faqs: FAQ[] }) {
+export function FAQ({ faqs }: { faqs: FAQ[] }) {
   return (
     <div className="mx-auto mt-32 max-w-4xl px-6 pb-8 sm:pb-24 sm:pt-12 lg:max-w-7xl lg:px-8 lg:py-32">
       <h2 className="text-foreground mb-12 text-center text-2xl font-bold leading-10 tracking-tight">

--- a/template/app/src/landing-page/components/Features.tsx
+++ b/template/app/src/landing-page/components/Features.tsx
@@ -1,4 +1,4 @@
-import SectionTitle from "./SectionTitle";
+import { SectionTitle } from "./SectionTitle";
 
 export interface Feature {
   name: string;
@@ -7,7 +7,7 @@ export interface Feature {
   href: string;
 }
 
-export default function Features({ features }: { features: Feature[] }) {
+export function Features({ features }: { features: Feature[] }) {
   return (
     <div id="features" className="mx-auto mt-48 max-w-7xl px-6 lg:px-8">
       <SectionTitle

--- a/template/app/src/landing-page/components/FeaturesGrid.tsx
+++ b/template/app/src/landing-page/components/FeaturesGrid.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../client/components/ui/card";
 import { cn } from "../../client/utils";
 import { Feature } from "./Features";
-import SectionTitle from "./SectionTitle";
+import { SectionTitle } from "./SectionTitle";
 
 export interface GridFeature extends Omit<Feature, "icon"> {
   icon?: React.ReactNode;
@@ -23,7 +23,10 @@ interface FeaturesGridProps {
   className?: string;
 }
 
-const FeaturesGrid = ({ features, className = "" }: FeaturesGridProps) => {
+export const FeaturesGrid = ({
+  features,
+  className = "",
+}: FeaturesGridProps) => {
   return (
     <div
       className="mx-auto my-16 flex max-w-7xl flex-col gap-4 md:my-24 lg:my-40"
@@ -150,5 +153,3 @@ function FeaturesGridItem({
 
   return gridFeatureCard;
 }
-
-export default FeaturesGrid;

--- a/template/app/src/landing-page/components/Footer.tsx
+++ b/template/app/src/landing-page/components/Footer.tsx
@@ -3,7 +3,7 @@ interface NavigationItem {
   href: string;
 }
 
-export default function Footer({
+export function Footer({
   footerNavigation,
 }: {
   footerNavigation: {

--- a/template/app/src/landing-page/components/Hero.tsx
+++ b/template/app/src/landing-page/components/Hero.tsx
@@ -3,7 +3,7 @@ import { Button } from "../../client/components/ui/button";
 import openSaasBannerDark from "../../client/static/open-saas-banner-dark.svg";
 import openSaasBannerLight from "../../client/static/open-saas-banner-light.svg";
 
-export default function Hero() {
+export function Hero() {
   return (
     <div className="relative w-full pt-14">
       <TopGradient />

--- a/template/app/src/landing-page/components/HighlightedFeature.tsx
+++ b/template/app/src/landing-page/components/HighlightedFeature.tsx
@@ -12,7 +12,7 @@ interface FeatureProps {
  * A component that highlights a feature with a description and a highlighted component.
  * Shows text description on one side, and whatever component you want to show on the other side to demonstrate the functionality.
  */
-const HighlightedFeature = ({
+export const HighlightedFeature = ({
   name,
   description,
   direction = "row",
@@ -50,5 +50,3 @@ const HighlightedFeature = ({
     </div>
   );
 };
-
-export default HighlightedFeature;

--- a/template/app/src/landing-page/components/SectionTitle.tsx
+++ b/template/app/src/landing-page/components/SectionTitle.tsx
@@ -1,4 +1,4 @@
-export default function SectionTitle({
+export function SectionTitle({
   title,
   description,
 }: {

--- a/template/app/src/landing-page/components/Testimonials.tsx
+++ b/template/app/src/landing-page/components/Testimonials.tsx
@@ -6,7 +6,7 @@ import {
   CardFooter,
   CardTitle,
 } from "../../client/components/ui/card";
-import SectionTitle from "./SectionTitle";
+import { SectionTitle } from "./SectionTitle";
 
 interface Testimonial {
   name: string;
@@ -16,7 +16,7 @@ interface Testimonial {
   quote: string;
 }
 
-export default function Testimonials({
+export function Testimonials({
   testimonials,
 }: {
   testimonials: Testimonial[];

--- a/template/app/src/landing-page/logos/AstroLogo.tsx
+++ b/template/app/src/landing-page/logos/AstroLogo.tsx
@@ -1,4 +1,4 @@
-export default function AstroLogo() {
+export function AstroLogo() {
   return (
     <svg viewBox="0 0 256 370" xmlns="http://www.w3.org/2000/svg">
       <path

--- a/template/app/src/landing-page/logos/OpenAILogo.tsx
+++ b/template/app/src/landing-page/logos/OpenAILogo.tsx
@@ -1,4 +1,4 @@
-export default function OpenAILogo() {
+export function OpenAILogo() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/template/app/src/landing-page/logos/PrismaLogo.tsx
+++ b/template/app/src/landing-page/logos/PrismaLogo.tsx
@@ -1,4 +1,4 @@
-export default function PrismaLogo() {
+export function PrismaLogo() {
   return (
     <svg
       width={48}

--- a/template/app/src/landing-page/logos/SalesforceLogo.tsx
+++ b/template/app/src/landing-page/logos/SalesforceLogo.tsx
@@ -1,4 +1,4 @@
-export default function SalesforceLogo() {
+export function SalesforceLogo() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273 191">
       <defs>

--- a/template/app/src/payment/CheckoutResultPage.tsx
+++ b/template/app/src/payment/CheckoutResultPage.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate, useSearchParams } from "react-router";
 
 const ACCOUNT_PAGE_REDIRECT_DELAY_MS = 4000;
 
-export default function CheckoutResultPage() {
+export function CheckoutResultPage() {
   const navigate = useNavigate();
   const [urlSearchParams] = useSearchParams();
   const status = urlSearchParams.get("status");

--- a/template/app/src/payment/PricingPage.tsx
+++ b/template/app/src/payment/PricingPage.tsx
@@ -53,7 +53,7 @@ export const paymentPlanCards: Record<PaymentPlanId, PaymentPlanCard> = {
   },
 };
 
-const PricingPage = () => {
+export const PricingPage = () => {
   const [isPaymentLoading, setIsPaymentLoading] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -234,5 +234,3 @@ const PricingPage = () => {
     </div>
   );
 };
-
-export default PricingPage;

--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -16,7 +16,7 @@ import {
   prettyPaymentPlanName,
 } from "../payment/plans";
 
-export default function AccountPage({ user }: { user: User }) {
+export function AccountPage({ user }: { user: User }) {
   return (
     <div className="mt-10 px-6">
       <Card className="mb-4 lg:m-8">


### PR DESCRIPTION
Changes all default exports to named exports.
Now there is only a single export type used through the codebase.

We agreed previously that Wasp team prefers the named exports.