### PR TITLE
Make payment URLs a bit more typesafe

### DIFF
--- a/opensaas-sh/app_diff/src/payment/stripe/paymentProcessor.ts.diff
+++ b/opensaas-sh/app_diff/src/payment/stripe/paymentProcessor.ts.diff
@@ -42,6 +42,6 @@
        await stripeClient.billingPortal.sessions.create({
 -        customer: paymentProcessorUserId,
 +        customer: stripeId,
-         return_url: `${config.frontendUrl}/account`,
+         return_url: CUSTOMER_PORTAL_RETURN_URL,
        });
  

--- a/template/app/src/payment/CheckoutResultPage.tsx
+++ b/template/app/src/payment/CheckoutResultPage.tsx
@@ -4,6 +4,11 @@ import { Link, routes } from "wasp/client/router";
 
 const ACCOUNT_PAGE_REDIRECT_DELAY_MS = 4000;
 
+export enum CheckoutResult {
+  Success = "success",
+  Canceled = "canceled",
+}
+
 export function CheckoutResultPage() {
   const navigate = useNavigate();
   const [urlSearchParams] = useSearchParams();
@@ -19,7 +24,10 @@ export function CheckoutResultPage() {
     };
   }, [navigate]);
 
-  if (status !== "success" && status !== "canceled") {
+  if (
+    status === null ||
+    (status !== CheckoutResult.Success && status !== CheckoutResult.Canceled)
+  ) {
     return <Link to={routes.AccountRoute.to} />;
   }
 
@@ -27,8 +35,8 @@ export function CheckoutResultPage() {
     <div className="mt-10 flex flex-col items-stretch sm:mx-6 sm:items-center">
       <div className="flex flex-col gap-4 px-4 py-8 text-center shadow-xl ring-1 ring-gray-900/10 sm:max-w-md sm:rounded-lg sm:px-10 dark:ring-gray-100/10">
         <h1 className="text-xl font-semibold">
-          {status === "success" && "🥳 Payment Successful!"}
-          {status === "canceled" && "😢 Payment Canceled."}
+          {status === CheckoutResult.Success && "🥳 Payment Successful!"}
+          {status === CheckoutResult.Canceled && "😢 Payment Canceled."}
         </h1>
         <span className="">
           You will be redirected to your account page in{" "}

--- a/template/app/src/payment/lemonSqueezy/checkoutUtils.ts
+++ b/template/app/src/payment/lemonSqueezy/checkoutUtils.ts
@@ -1,4 +1,5 @@
 import { createCheckout } from "@lemonsqueezy/lemonsqueezy.js";
+import { CHECKOUT_SUCCESS_URL } from "../paths";
 
 interface LemonSqueezyCheckoutSessionParams {
   storeId: string;
@@ -19,6 +20,9 @@ export async function createLemonSqueezyCheckoutSession({
       custom: {
         user_id: userId, // You app's unique user ID is sent on checkout, and it's returned in the webhook so we can easily identify the user.
       },
+    },
+    productOptions: {
+      redirectUrl: CHECKOUT_SUCCESS_URL,
     },
   });
   if (error) {

--- a/template/app/src/payment/paths.ts
+++ b/template/app/src/payment/paths.ts
@@ -1,0 +1,19 @@
+import { routes } from "wasp/client/router";
+import { config } from "wasp/server";
+import { CheckoutResult } from "./CheckoutResultPage";
+
+const CHECKOUT_SUCCESS_URL_PATH = routes.CheckoutResultRoute.build({
+  search: {
+    status: CheckoutResult.Success,
+  },
+});
+export const CHECKOUT_SUCCESS_URL = `${config.frontendUrl}${CHECKOUT_SUCCESS_URL_PATH}`;
+
+const CHECKOUT_CANCELED_URL_PATH = routes.CheckoutResultRoute.build({
+  search: {
+    status: CheckoutResult.Canceled,
+  },
+});
+export const CHECKOUT_CANCELED_URL = `${config.frontendUrl}${CHECKOUT_CANCELED_URL_PATH}`;
+
+export const CUSTOMER_PORTAL_RETURN_URL = `${config.frontendUrl}${routes.AccountRoute.to}`;

--- a/template/app/src/payment/polar/checkoutUtils.ts
+++ b/template/app/src/payment/polar/checkoutUtils.ts
@@ -1,6 +1,6 @@
 import { Checkout } from "@polar-sh/sdk/models/components/checkout.js";
 import { Customer } from "@polar-sh/sdk/models/components/customer.js";
-import { config } from "wasp/server";
+import { CHECKOUT_SUCCESS_URL } from "../paths";
 import { polarClient } from "./polarClient";
 
 /**
@@ -38,7 +38,7 @@ export function createPolarCheckoutSession({
 }: CreatePolarCheckoutSessionArgs): Promise<Checkout> {
   return polarClient.checkouts.create({
     products: [productId],
-    successUrl: `${config.frontendUrl}/checkout?status=success`,
+    successUrl: CHECKOUT_SUCCESS_URL,
     customerId,
   });
 }

--- a/template/app/src/payment/stripe/checkoutUtils.ts
+++ b/template/app/src/payment/stripe/checkoutUtils.ts
@@ -1,6 +1,6 @@
 import Stripe from "stripe";
 import { User } from "wasp/entities";
-import { config } from "wasp/server";
+import { CHECKOUT_CANCELED_URL, CHECKOUT_SUCCESS_URL } from "../paths";
 import { stripeClient } from "./stripeClient";
 
 /**
@@ -43,8 +43,8 @@ export function createStripeCheckoutSession({
       },
     ],
     mode,
-    success_url: `${config.frontendUrl}/checkout?status=success`,
-    cancel_url: `${config.frontendUrl}/checkout?status=canceled`,
+    success_url: CHECKOUT_SUCCESS_URL,
+    cancel_url: CHECKOUT_CANCELED_URL,
     automatic_tax: { enabled: true },
     allow_promotion_codes: true,
     customer_update: {

--- a/template/app/src/payment/stripe/paymentProcessor.ts
+++ b/template/app/src/payment/stripe/paymentProcessor.ts
@@ -1,6 +1,6 @@
 import Stripe from "stripe";
-import { config } from "wasp/server";
 import { assertUnreachable } from "../../shared/utils";
+import { CUSTOMER_PORTAL_RETURN_URL } from "../paths";
 import type {
   CreateCheckoutSessionArgs,
   FetchCustomerPortalUrlArgs,
@@ -69,7 +69,7 @@ export const stripePaymentProcessor: PaymentProcessor = {
     const billingPortalSession =
       await stripeClient.billingPortal.sessions.create({
         customer: paymentProcessorUserId,
-        return_url: `${config.frontendUrl}/account`,
+        return_url: CUSTOMER_PORTAL_RETURN_URL,
       });
 
     return billingPortalSession.url;


### PR DESCRIPTION
Fixes #573 

Make checkout result and customer portal URLs a bit more typesafe.
Ideally we would support declaring search query types on routes.

Kinda like tanstack: https://tanstack.com/router/latest/docs/guide/search-params#validating-and-typing-search-params