### PR TITLE
fix(account): fix the subscription end date bug

### DIFF
--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -151,13 +151,20 @@ function formatSubscriptionStatusMessage(
   return statusToMessage[subscriptionStatus];
 }
 
-function prettyPrintEndOfBillingPeriod(date: Date) {
-  const targetMonth = date.getMonth() + 1;
-  const targetYear = date.getFullYear() + (targetMonth > 11 ? 1 : 0);
-  const normalizedMonth = targetMonth % 12;
-  const lastDayOfMonth = new Date(targetYear, normalizedMonth + 1, 0).getDate();
-  const clampedDay = Math.min(date.getDate(), lastDayOfMonth);
-  return new Date(targetYear, normalizedMonth, clampedDay).toLocaleDateString();
+function prettyPrintEndOfBillingPeriod(datePaid: Date) {
+  const lastDayOfNextMonth = new Date(datePaid);
+  lastDayOfNextMonth.setMonth(lastDayOfNextMonth.getMonth() + 2, 0);
+  // Clamped so e.g., Jan 31 + 1 month → Feb 28, not until March 3.
+  const clampedDayOfMonth = Math.min(
+    datePaid.getDate(),
+    lastDayOfNextMonth.getDate(),
+  );
+  const endOfBillingPeriod = new Date(datePaid);
+  endOfBillingPeriod.setMonth(
+    endOfBillingPeriod.getMonth() + 1,
+    clampedDayOfMonth,
+  );
+  return endOfBillingPeriod.toLocaleDateString();
 }
 
 function CustomerPortalButton() {

--- a/template/app/src/user/AccountPage.tsx
+++ b/template/app/src/user/AccountPage.tsx
@@ -152,9 +152,12 @@ function formatSubscriptionStatusMessage(
 }
 
 function prettyPrintEndOfBillingPeriod(date: Date) {
-  const oneMonthFromNow = new Date(date);
-  oneMonthFromNow.setMonth(oneMonthFromNow.getMonth() + 1);
-  return oneMonthFromNow.toLocaleDateString();
+  const targetMonth = date.getMonth() + 1;
+  const targetYear = date.getFullYear() + (targetMonth > 11 ? 1 : 0);
+  const normalizedMonth = targetMonth % 12;
+  const lastDayOfMonth = new Date(targetYear, normalizedMonth + 1, 0).getDate();
+  const clampedDay = Math.min(date.getDate(), lastDayOfMonth);
+  return new Date(targetYear, normalizedMonth, clampedDay).toLocaleDateString();
 }
 
 function CustomerPortalButton() {


### PR DESCRIPTION
## Description

Fixes #657

This PR fixes the subscription end date bug, which happens only for February.

Testing scenario:
- datePaid: '2026-01-31'
- subscriptionPlan: 'hobby'
- subscriptionStatus = 'cancel_at_period_end'

Before fixing:
<img width="1440" height="617" alt="Screenshot from 2026-05-19 20-57-43" src="https://github.com/user-attachments/assets/39c93ad3-ab55-4869-81ca-5247de912363" />

After fixing:
<img width="1440" height="617" alt="Screenshot from 2026-05-19 20-57-01" src="https://github.com/user-attachments/assets/7c87f2d1-73d5-4441-89e9-ca57f0db949f" />

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [✅] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [✅] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [✅] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
