### PR TITLE
Upgrade to latest Wasp 0.25 changes

### DIFF
--- a/opensaas-sh/app_diff/package-lock.json.diff
+++ b/opensaas-sh/app_diff/package-lock.json.diff
@@ -61,7 +61,7 @@
 +        "@types/react": "^19.2.7",
 +        "@wasp.sh/spec": "file:.wasp/spec",
 +        "prisma": "5.19.1",
-+        "typescript": "5.9.3",
++        "typescript": "6.0.3",
 +        "vite": "^7.0.6",
 +        "vitest": "^4.0.16"
 +      }
@@ -75,7 +75,7 @@
 +        "estree-util-scope": "^1.0.0",
 +        "estree-walker": "^3.0.3",
 +        "type-fest": "^5.6.0",
-+        "typescript": "^5.8.3",
++        "typescript": "^6.0.3",
 +        "unrun": "^0.3.0"
 +      },
 +      "bin": {
@@ -8146,9 +8146,9 @@
 +      }
 +    },
 +    "node_modules/typescript": {
-+      "version": "5.9.3",
-+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
++      "version": "6.0.3",
++      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
++      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "bin": {

--- a/template/app/package.json
+++ b/template/app/package.json
@@ -55,7 +55,7 @@
     "@types/react": "^19.2.7",
     "@wasp.sh/spec": "file:.wasp/spec",
     "prisma": "5.19.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "^7.0.6",
     "vitest": "^4.0.16"
   }

--- a/template/app/tsconfig.src.json
+++ b/template/app/tsconfig.src.json
@@ -22,7 +22,8 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "allowJs": true,
-    "outDir": ".wasp/out/user"
+    "outDir": ".wasp/out/user",
+    "types": ["react", "node"]
   },
   "include": ["src"],
   "exclude": ["**/*.wasp.ts"]

--- a/template/app/tsconfig.wasp.json
+++ b/template/app/tsconfig.wasp.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "skipLibCheck": true,
-    "target": "ES2022",
+    "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
 
@@ -15,7 +15,8 @@
     "allowJs": true,
     "noEmit": true,
 
-    "lib": ["ES2023"]
+    "lib": ["ES2025"],
+    "types": ["node"]
   },
   "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }


### PR DESCRIPTION
## Description

Wasp 0.25 validates `tsconfig.wasp.json` and `tsconfig.src.json` against its `skeleton` starter and fails compilation on mismatch, but these files still held the 0.24 values. This updates `template/app/tsconfig.wasp.json` (`target` and `lib` from ES2022/ES2023 to ES2025, plus `"types": ["node"]`) and `template/app/tsconfig.src.json` (adds `"types": ["react", "node"]`) to match. Values were taken from the 0.25 CLI's `data/Cli/starters/skeleton` templates.

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details. (N/A: these tsconfig files are not referenced by app_diff.)
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).