### PR TITLE
fix(e2e): use IPv4 for webServer readiness to stop ::1 ECONNREFUSED timeouts

### DIFF
--- a/template/e2e-tests/playwright.config.ts
+++ b/template/e2e-tests/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   webServer: {
     command: "run-wasp-app dev --path-to-app=../app --wasp-cli-cmd=wasp",
     // Wait for the backend to start
-    url: "http://localhost:3001",
+    url: "http://127.0.0.1:3001",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },


### PR DESCRIPTION
## Problem
e2e `test` job flakily fails to start the web server. On GitHub runners `localhost` resolves to `::1` first; the backend binds IPv4, so Playwright's readiness check gets `connect ECONNREFUSED ::1:3001`. Fallback to `127.0.0.1` happens but can miss the 120s timeout → fail.

Repro on `main`: run [#28524177274](https://github.com/wasp-lang/open-saas/actions/runs/28524177274) (fail) and [#28529757174](https://github.com/wasp-lang/open-saas/actions/runs/28529757174) (pass — also starts with `::1` errors).

## Fix
```diff
-    url: "http://localhost:3001",
+    url: "http://127.0.0.1:3001",
```
Deterministic, removes the `::1` race + log spam. `baseURL` left as `localhost:3000` since the browser uses Happy Eyeballs and handles it fine.
