### PR TITLE
Fix Wasp wrapper cache busting

### DIFF
--- a/tools/wasp
+++ b/tools/wasp
@@ -18,4 +18,4 @@ if [ -z "$latest_commit" ]; then
   exit 1
 fi
 
-npm_config_prefer_online=true npx -y "https://pkg.pr.new/@wasp.sh/wasp-cli@$latest_commit" "$@"
+exec npx -y "https://pkg.pr.new/@wasp.sh/wasp-cli@$latest_commit" "$@"

--- a/tools/wasp
+++ b/tools/wasp
@@ -2,4 +2,11 @@
 
 # Just a wrapper to always use the latest Wasp CLI from main branch.
 
-npm_config_prefer_online=true npx -y https://pkg.pr.new/@wasp.sh/wasp-cli@main "$@"
+latest_commit=$(git ls-remote https://github.com/wasp-lang/wasp.git refs/heads/main | cut -c1-7)
+
+if [ -z "$latest_commit" ]; then
+  printf '%s\n' "Failed to resolve latest Wasp commit from main." >&2
+  exit 1
+fi
+
+npm_config_prefer_online=true npx -y "https://pkg.pr.new/@wasp.sh/wasp-cli@$latest_commit" "$@"

--- a/tools/wasp
+++ b/tools/wasp
@@ -2,10 +2,10 @@
 
 # Just a wrapper to always use the latest Wasp CLI from main branch.
 
-latest_commit=$(git ls-remote https://github.com/wasp-lang/wasp.git refs/heads/main | cut -c1-7)
+latest_commit=$(curl -fsLI https://pkg.pr.new/@wasp.sh/wasp-cli@main | grep -i '^x-commit-key:' | cut -d: -f4- | tr -d '[:space:]')
 
 if [ -z "$latest_commit" ]; then
-  printf '%s\n' "Failed to resolve latest Wasp commit from main." >&2
+  printf '%s\n' "Failed to resolve latest published Wasp commit from main." >&2
   exit 1
 fi
 

--- a/tools/wasp
+++ b/tools/wasp
@@ -2,7 +2,16 @@
 
 # Just a wrapper to always use the latest Wasp CLI from main branch.
 
-latest_commit=$(curl -fsLI https://pkg.pr.new/@wasp.sh/wasp-cli@main | grep -i '^x-commit-key:' | cut -d: -f4- | tr -d '[:space:]')
+WASP_CLI_MAIN_URL="https://pkg.pr.new/@wasp.sh/wasp-cli@main"
+
+get_latest_published_commit() {
+  curl -fsLI "$WASP_CLI_MAIN_URL" |
+    grep -i '^x-commit-key:' |
+    cut -d: -f4- |
+    tr -d '[:space:]'
+}
+
+latest_commit=$(get_latest_published_commit)
 
 if [ -z "$latest_commit" ]; then
   printf '%s\n' "Failed to resolve latest published Wasp commit from main." >&2


### PR DESCRIPTION
## Summary
- Resolve pkg.pr.new current published Wasp main commit from the `x-commit-key` response header
- Run the commit-pinned pkg.pr.new package instead of mutable `@main`, so npm cache keys update when pkg.pr.new updates
- Keep a clear failure message if pkg.pr.new does not expose the published commit

## Testing
- `./tools/wasp version`
- `shellcheck tools/wasp`