### PR TITLE
Wasp 0.25 migration: React Router 8, Vite 8, Vitest 4.1

### DIFF
--- a/opensaas-sh/app_diff/package-lock.json.diff
+++ b/opensaas-sh/app_diff/package-lock.json.diff
@@ -1,6 +1,6 @@
 --- template/app/package-lock.json
 +++ opensaas-sh/app/package-lock.json
-@@ -0,0 +1,8632 @@
+@@ -0,0 +1,7693 @@
 +{
 +  "name": "opensaas",
 +  "lockfileVersion": 3,
@@ -45,7 +45,7 @@
 +        "react-dom": "^19.2.1",
 +        "react-hook-form": "^7.60.0",
 +        "react-icons": "^5.5.0",
-+        "react-router": "^7.12.0",
++        "react-router": "^8.0.1",
 +        "stripe": "18.1.0",
 +        "tailwind-merge": "^2.2.1",
 +        "tailwindcss": "^4.1.18",
@@ -55,15 +55,15 @@
 +      },
 +      "devDependencies": {
 +        "@faker-js/faker": "8.3.1",
-+        "@tailwindcss/vite": "^4.1.18",
++        "@tailwindcss/vite": "^4.3.1",
 +        "@types/express": "^5.0.0",
 +        "@types/node": "^24.0.0",
 +        "@types/react": "^19.2.7",
 +        "@wasp.sh/spec": "file:.wasp/spec",
 +        "prisma": "5.19.1",
 +        "typescript": "6.0.3",
-+        "vite": "^7.0.6",
-+        "vitest": "^4.0.16"
++        "vite": "^8.1.0",
++        "vitest": "^4.1.9"
 +      }
 +    },
 +    ".wasp/spec": {
@@ -84,12 +84,12 @@
 +      "devDependencies": {
 +        "@eslint/js": "^9.9.0",
 +        "@types/node": "^22.17.0",
-+        "@vitest/coverage-v8": "^4.0.16",
++        "@vitest/coverage-v8": "^4.1.9",
 +        "eslint": "^9.9.0",
 +        "globals": "^15.9.0",
 +        "nodemon": "^3.1.4",
 +        "typescript-eslint": "^8.1.0",
-+        "vitest": "^4.0.16"
++        "vitest": "^4.1.9"
 +      }
 +    },
 +    ".wasp/spec/node_modules/@types/node": {
@@ -643,9 +643,9 @@
 +      }
 +    },
 +    "node_modules/@babel/helper-string-parser": {
-+      "version": "7.27.1",
-+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
++      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -653,9 +653,9 @@
 +      }
 +    },
 +    "node_modules/@babel/helper-validator-identifier": {
-+      "version": "7.28.5",
-+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
++      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -663,13 +663,13 @@
 +      }
 +    },
 +    "node_modules/@babel/parser": {
-+      "version": "7.29.3",
-+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
++      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@babel/types": "^7.29.0"
++        "@babel/types": "^7.29.7"
 +      },
 +      "bin": {
 +        "parser": "bin/babel-parser.js"
@@ -679,14 +679,14 @@
 +      }
 +    },
 +    "node_modules/@babel/types": {
-+      "version": "7.29.0",
-+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
++      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@babel/helper-string-parser": "^7.27.1",
-+        "@babel/helper-validator-identifier": "^7.28.5"
++        "@babel/helper-string-parser": "^7.29.7",
++        "@babel/helper-validator-identifier": "^7.29.7"
 +      },
 +      "engines": {
 +        "node": ">=6.9.0"
@@ -703,9 +703,9 @@
 +      }
 +    },
 +    "node_modules/@emnapi/core": {
-+      "version": "1.11.0",
-+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
++      "version": "1.11.1",
++      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
++      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "optional": true,
@@ -715,9 +715,9 @@
 +      }
 +    },
 +    "node_modules/@emnapi/runtime": {
-+      "version": "1.11.0",
-+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
++      "version": "1.11.1",
++      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
++      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "optional": true,
@@ -734,448 +734,6 @@
 +      "optional": true,
 +      "dependencies": {
 +        "tslib": "^2.4.0"
-+      }
-+    },
-+    "node_modules/@esbuild/aix-ppc64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "aix"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/android-arm": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/android-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/android-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/darwin-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/darwin-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/freebsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/freebsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-arm": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-ia32": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-loong64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-+      "cpu": [
-+        "loong64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-mips64el": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-+      "cpu": [
-+        "mips64el"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-ppc64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-riscv64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-+      "cpu": [
-+        "riscv64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-s390x": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-+      "cpu": [
-+        "s390x"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/linux-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/netbsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "netbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/netbsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "netbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/openbsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/openbsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/openharmony-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openharmony"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/sunos-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "sunos"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/win32-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/win32-ia32": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/@esbuild/win32-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
 +      }
 +    },
 +    "node_modules/@eslint-community/eslint-utils": {
@@ -1591,16 +1149,22 @@
 +      }
 +    },
 +    "node_modules/@napi-rs/wasm-runtime": {
-+      "version": "0.2.12",
-+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
++      "version": "1.1.6",
++      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
++      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "optional": true,
 +      "dependencies": {
-+        "@emnapi/core": "^1.4.3",
-+        "@emnapi/runtime": "^1.4.3",
-+        "@tybys/wasm-util": "^0.10.0"
++        "@tybys/wasm-util": "^0.10.3"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Brooooooklyn"
++      },
++      "peerDependencies": {
++        "@emnapi/core": "^1.7.1",
++        "@emnapi/runtime": "^1.7.1"
 +      }
 +    },
 +    "node_modules/@nodable/entities": {
@@ -1616,9 +1180,9 @@
 +      "license": "MIT"
 +    },
 +    "node_modules/@oxc-project/types": {
-+      "version": "0.135.0",
-+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
-+      "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
++      "version": "0.138.0",
++      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
++      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "funding": {
@@ -2876,9 +2440,9 @@
 +      "license": "MIT"
 +    },
 +    "node_modules/@rolldown/binding-android-arm64": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.1.tgz",
-+      "integrity": "sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
++      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -2893,9 +2457,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-darwin-arm64": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.1.tgz",
-+      "integrity": "sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
++      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -2910,9 +2474,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-darwin-x64": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.1.tgz",
-+      "integrity": "sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
++      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -2927,9 +2491,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-freebsd-x64": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.1.tgz",
-+      "integrity": "sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
++      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -2944,9 +2508,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.1.tgz",
-+      "integrity": "sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
++      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -2961,9 +2525,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.1.tgz",
-+      "integrity": "sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
++      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -2981,9 +2545,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-arm64-musl": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.1.tgz",
-+      "integrity": "sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
++      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3001,9 +2565,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.1.tgz",
-+      "integrity": "sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
++      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
 +      "cpu": [
 +        "ppc64"
 +      ],
@@ -3021,9 +2585,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.1.tgz",
-+      "integrity": "sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
++      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
 +      "cpu": [
 +        "s390x"
 +      ],
@@ -3041,9 +2605,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-x64-gnu": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.1.tgz",
-+      "integrity": "sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
++      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3061,9 +2625,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-linux-x64-musl": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.1.tgz",
-+      "integrity": "sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
++      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3081,9 +2645,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-openharmony-arm64": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.1.tgz",
-+      "integrity": "sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
++      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3098,9 +2662,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-wasm32-wasi": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.1.tgz",
-+      "integrity": "sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
++      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
 +      "cpu": [
 +        "wasm32"
 +      ],
@@ -3108,37 +2672,18 @@
 +      "license": "MIT",
 +      "optional": true,
 +      "dependencies": {
-+        "@emnapi/core": "1.11.0",
-+        "@emnapi/runtime": "1.11.0",
-+        "@napi-rs/wasm-runtime": "^1.1.5"
++        "@emnapi/core": "1.11.1",
++        "@emnapi/runtime": "1.11.1",
++        "@napi-rs/wasm-runtime": "^1.1.6"
 +      },
 +      "engines": {
 +        "node": "^20.19.0 || >=22.12.0"
 +      }
 +    },
-+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-+      "version": "1.1.5",
-+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "dependencies": {
-+        "@tybys/wasm-util": "^0.10.2"
-+      },
-+      "funding": {
-+        "type": "github",
-+        "url": "https://github.com/sponsors/Brooooooklyn"
-+      },
-+      "peerDependencies": {
-+        "@emnapi/core": "^1.7.1",
-+        "@emnapi/runtime": "^1.7.1"
-+      }
-+    },
 +    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.1.tgz",
-+      "integrity": "sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
++      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3153,9 +2698,9 @@
 +      }
 +    },
 +    "node_modules/@rolldown/binding-win32-x64-msvc": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.1.tgz",
-+      "integrity": "sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
++      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3168,395 +2713,6 @@
 +      "engines": {
 +        "node": "^20.19.0 || >=22.12.0"
 +      }
-+    },
-+    "node_modules/@rollup/rollup-android-arm-eabi": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-android-arm64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-darwin-arm64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-darwin-x64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-freebsd-arm64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-freebsd-x64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-arm64-musl": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
-+      "cpu": [
-+        "loong64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-loong64-musl": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-+      "cpu": [
-+        "loong64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
-+      "cpu": [
-+        "riscv64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
-+      "cpu": [
-+        "riscv64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
-+      "cpu": [
-+        "s390x"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-x64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "glibc"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-linux-x64-musl": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "libc": [
-+        "musl"
-+      ],
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-openbsd-x64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openbsd"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-openharmony-arm64": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openharmony"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-win32-x64-gnu": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ]
-+    },
-+    "node_modules/@rollup/rollup-win32-x64-msvc": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ]
 +    },
 +    "node_modules/@smithy/core": {
 +      "version": "3.24.3",
@@ -3704,49 +2860,49 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/node": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
++      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
 +        "@jridgewell/remapping": "^2.3.5",
-+        "enhanced-resolve": "^5.21.0",
-+        "jiti": "^2.6.1",
++        "enhanced-resolve": "5.21.6",
++        "jiti": "^2.7.0",
 +        "lightningcss": "1.32.0",
 +        "magic-string": "^0.30.21",
 +        "source-map-js": "^1.2.1",
-+        "tailwindcss": "4.3.0"
++        "tailwindcss": "4.3.2"
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
++      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
 +        "node": ">= 20"
 +      },
 +      "optionalDependencies": {
-+        "@tailwindcss/oxide-android-arm64": "4.3.0",
-+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
-+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
-+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
-+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
++        "@tailwindcss/oxide-android-arm64": "4.3.2",
++        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
++        "@tailwindcss/oxide-darwin-x64": "4.3.2",
++        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
++        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
++        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
++        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
++        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
++        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
++        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
++        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
++        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-android-arm64": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
++      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3761,9 +2917,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
++      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3778,9 +2934,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-darwin-x64": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
++      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3795,9 +2951,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
++      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3812,9 +2968,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
++      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -3829,9 +2985,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
++      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3849,9 +3005,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
++      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3869,9 +3025,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
++      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3889,9 +3045,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
++      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3909,9 +3065,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
++      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
 +      "bundleDependencies": [
 +        "@napi-rs/wasm-runtime",
 +        "@emnapi/core",
@@ -3927,11 +3083,11 @@
 +      "license": "MIT",
 +      "optional": true,
 +      "dependencies": {
-+        "@emnapi/core": "^1.10.0",
-+        "@emnapi/runtime": "^1.10.0",
-+        "@emnapi/wasi-threads": "^1.2.1",
++        "@emnapi/core": "^1.11.1",
++        "@emnapi/runtime": "^1.11.1",
++        "@emnapi/wasi-threads": "^1.2.2",
 +        "@napi-rs/wasm-runtime": "^1.1.4",
-+        "@tybys/wasm-util": "^0.10.1",
++        "@tybys/wasm-util": "^0.10.2",
 +        "tslib": "^2.8.1"
 +      },
 +      "engines": {
@@ -3939,9 +3095,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
++      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -3956,9 +3112,9 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
++      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -3985,15 +3141,15 @@
 +      }
 +    },
 +    "node_modules/@tailwindcss/vite": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
++      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@tailwindcss/node": "4.3.0",
-+        "@tailwindcss/oxide": "4.3.0",
-+        "tailwindcss": "4.3.0"
++        "@tailwindcss/node": "4.3.2",
++        "@tailwindcss/oxide": "4.3.2",
++        "tailwindcss": "4.3.2"
 +      },
 +      "peerDependencies": {
 +        "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -4009,9 +3165,9 @@
 +      }
 +    },
 +    "node_modules/@tybys/wasm-util": {
-+      "version": "0.10.2",
-+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
++      "version": "0.10.3",
++      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
++      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "optional": true,
@@ -4488,14 +3644,14 @@
 +      }
 +    },
 +    "node_modules/@vitest/coverage-v8": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
++      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
 +        "@bcoe/v8-coverage": "^1.0.2",
-+        "@vitest/utils": "4.1.6",
++        "@vitest/utils": "4.1.9",
 +        "ast-v8-to-istanbul": "^1.0.0",
 +        "istanbul-lib-coverage": "^3.2.2",
 +        "istanbul-lib-report": "^3.0.1",
@@ -4509,8 +3665,8 @@
 +        "url": "https://opencollective.com/vitest"
 +      },
 +      "peerDependencies": {
-+        "@vitest/browser": "4.1.6",
-+        "vitest": "4.1.6"
++        "@vitest/browser": "4.1.9",
++        "vitest": "4.1.9"
 +      },
 +      "peerDependenciesMeta": {
 +        "@vitest/browser": {
@@ -4519,16 +3675,16 @@
 +      }
 +    },
 +    "node_modules/@vitest/expect": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
++      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
 +        "@standard-schema/spec": "^1.1.0",
 +        "@types/chai": "^5.2.2",
-+        "@vitest/spy": "4.1.6",
-+        "@vitest/utils": "4.1.6",
++        "@vitest/spy": "4.1.9",
++        "@vitest/utils": "4.1.9",
 +        "chai": "^6.2.2",
 +        "tinyrainbow": "^3.1.0"
 +      },
@@ -4537,13 +3693,13 @@
 +      }
 +    },
 +    "node_modules/@vitest/mocker": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
++      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@vitest/spy": "4.1.6",
++        "@vitest/spy": "4.1.9",
 +        "estree-walker": "^3.0.3",
 +        "magic-string": "^0.30.21"
 +      },
@@ -4564,9 +3720,9 @@
 +      }
 +    },
 +    "node_modules/@vitest/pretty-format": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
++      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -4577,13 +3733,13 @@
 +      }
 +    },
 +    "node_modules/@vitest/runner": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
++      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@vitest/utils": "4.1.6",
++        "@vitest/utils": "4.1.9",
 +        "pathe": "^2.0.3"
 +      },
 +      "funding": {
@@ -4591,14 +3747,14 @@
 +      }
 +    },
 +    "node_modules/@vitest/snapshot": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
++      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@vitest/pretty-format": "4.1.6",
-+        "@vitest/utils": "4.1.6",
++        "@vitest/pretty-format": "4.1.9",
++        "@vitest/utils": "4.1.9",
 +        "magic-string": "^0.30.21",
 +        "pathe": "^2.0.3"
 +      },
@@ -4607,9 +3763,9 @@
 +      }
 +    },
 +    "node_modules/@vitest/spy": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
++      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "funding": {
@@ -4617,13 +3773,13 @@
 +      }
 +    },
 +    "node_modules/@vitest/utils": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
++      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@vitest/pretty-format": "4.1.6",
++        "@vitest/pretty-format": "4.1.9",
 +        "convert-source-map": "^2.0.0",
 +        "tinyrainbow": "^3.1.0"
 +      },
@@ -4795,9 +3951,9 @@
 +      }
 +    },
 +    "node_modules/ast-v8-to-istanbul": {
-+      "version": "1.0.0",
-+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
++      "version": "1.0.4",
++      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
++      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -5087,18 +4243,11 @@
 +      "dev": true,
 +      "license": "MIT"
 +    },
-+    "node_modules/cookie": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-+      "license": "MIT",
-+      "engines": {
-+        "node": ">=18"
-+      },
-+      "funding": {
-+        "type": "opencollective",
-+        "url": "https://opencollective.com/express"
-+      }
++    "node_modules/cookie-es": {
++      "version": "3.1.1",
++      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
++      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
++      "license": "MIT"
 +    },
 +    "node_modules/cross-spawn": {
 +      "version": "7.0.6",
@@ -5258,9 +4407,9 @@
 +      }
 +    },
 +    "node_modules/enhanced-resolve": {
-+      "version": "5.21.3",
-+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
++      "version": "5.21.6",
++      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
++      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -5321,48 +4470,6 @@
 +      },
 +      "engines": {
 +        "node": ">= 0.4"
-+      }
-+    },
-+    "node_modules/esbuild": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-+      "dev": true,
-+      "hasInstallScript": true,
-+      "license": "MIT",
-+      "bin": {
-+        "esbuild": "bin/esbuild"
-+      },
-+      "engines": {
-+        "node": ">=18"
-+      },
-+      "optionalDependencies": {
-+        "@esbuild/aix-ppc64": "0.27.7",
-+        "@esbuild/android-arm": "0.27.7",
-+        "@esbuild/android-arm64": "0.27.7",
-+        "@esbuild/android-x64": "0.27.7",
-+        "@esbuild/darwin-arm64": "0.27.7",
-+        "@esbuild/darwin-x64": "0.27.7",
-+        "@esbuild/freebsd-arm64": "0.27.7",
-+        "@esbuild/freebsd-x64": "0.27.7",
-+        "@esbuild/linux-arm": "0.27.7",
-+        "@esbuild/linux-arm64": "0.27.7",
-+        "@esbuild/linux-ia32": "0.27.7",
-+        "@esbuild/linux-loong64": "0.27.7",
-+        "@esbuild/linux-mips64el": "0.27.7",
-+        "@esbuild/linux-ppc64": "0.27.7",
-+        "@esbuild/linux-riscv64": "0.27.7",
-+        "@esbuild/linux-s390x": "0.27.7",
-+        "@esbuild/linux-x64": "0.27.7",
-+        "@esbuild/netbsd-arm64": "0.27.7",
-+        "@esbuild/netbsd-x64": "0.27.7",
-+        "@esbuild/openbsd-arm64": "0.27.7",
-+        "@esbuild/openbsd-x64": "0.27.7",
-+        "@esbuild/openharmony-arm64": "0.27.7",
-+        "@esbuild/sunos-x64": "0.27.7",
-+        "@esbuild/win32-arm64": "0.27.7",
-+        "@esbuild/win32-ia32": "0.27.7",
-+        "@esbuild/win32-x64": "0.27.7"
 +      }
 +    },
 +    "node_modules/escalade": {
@@ -6757,9 +5864,9 @@
 +      "license": "MIT"
 +    },
 +    "node_modules/nanoid": {
-+      "version": "3.3.12",
-+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
++      "version": "3.3.15",
++      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
++      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -6934,15 +6041,18 @@
 +      }
 +    },
 +    "node_modules/obug": {
-+      "version": "2.1.1",
-+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
++      "version": "2.1.3",
++      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
++      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 +      "dev": true,
 +      "funding": [
 +        "https://github.com/sponsors/sxzz",
 +        "https://opencollective.com/debug"
 +      ],
-+      "license": "MIT"
++      "license": "MIT",
++      "engines": {
++        "node": ">=12.20.0"
++      }
 +    },
 +    "node_modules/once": {
 +      "version": "1.4.0",
@@ -7100,9 +6210,9 @@
 +      }
 +    },
 +    "node_modules/postcss": {
-+      "version": "8.5.14",
-+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
++      "version": "8.5.16",
++      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
++      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -7120,7 +6230,7 @@
 +      ],
 +      "license": "MIT",
 +      "dependencies": {
-+        "nanoid": "^3.3.11",
++        "nanoid": "^3.3.12",
 +        "picocolors": "^1.1.1",
 +        "source-map-js": "^1.2.1"
 +      },
@@ -7344,9 +6454,9 @@
 +      }
 +    },
 +    "node_modules/react": {
-+      "version": "19.2.6",
-+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
++      "version": "19.2.7",
++      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
++      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
 +      "license": "MIT",
 +      "engines": {
 +        "node": ">=0.10.0"
@@ -7366,15 +6476,15 @@
 +      }
 +    },
 +    "node_modules/react-dom": {
-+      "version": "19.2.6",
-+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
++      "version": "19.2.7",
++      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
++      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "scheduler": "^0.27.0"
 +      },
 +      "peerDependencies": {
-+        "react": "^19.2.6"
++        "react": "^19.2.7"
 +      }
 +    },
 +    "node_modules/react-hook-form": {
@@ -7456,20 +6566,19 @@
 +      }
 +    },
 +    "node_modules/react-router": {
-+      "version": "7.15.1",
-+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
++      "version": "8.1.0",
++      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.1.0.tgz",
++      "integrity": "sha512-Mdfi61uObuvWNN9OhChOC0HV6YWOIfKRzEWOvCHRSuQg8IM+Nv10edaM/2HE8ZixBpUTdQbruyWqC3sDkkh9vw==",
 +      "license": "MIT",
 +      "dependencies": {
-+        "cookie": "^1.0.1",
-+        "set-cookie-parser": "^2.6.0"
++        "cookie-es": "^3.1.1"
 +      },
 +      "engines": {
-+        "node": ">=20.0.0"
++        "node": ">=22.22.0"
 +      },
 +      "peerDependencies": {
-+        "react": ">=18",
-+        "react-dom": ">=18"
++        "react": ">=19.2.7",
++        "react-dom": ">=19.2.7"
 +      },
 +      "peerDependenciesMeta": {
 +        "react-dom": {
@@ -7573,13 +6682,13 @@
 +      }
 +    },
 +    "node_modules/rolldown": {
-+      "version": "1.1.1",
-+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.1.tgz",
-+      "integrity": "sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==",
++      "version": "1.1.4",
++      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
++      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@oxc-project/types": "=0.135.0",
++        "@oxc-project/types": "=0.138.0",
 +        "@rolldown/pluginutils": "^1.0.0"
 +      },
 +      "bin": {
@@ -7589,21 +6698,21 @@
 +        "node": "^20.19.0 || >=22.12.0"
 +      },
 +      "optionalDependencies": {
-+        "@rolldown/binding-android-arm64": "1.1.1",
-+        "@rolldown/binding-darwin-arm64": "1.1.1",
-+        "@rolldown/binding-darwin-x64": "1.1.1",
-+        "@rolldown/binding-freebsd-x64": "1.1.1",
-+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.1",
-+        "@rolldown/binding-linux-arm64-gnu": "1.1.1",
-+        "@rolldown/binding-linux-arm64-musl": "1.1.1",
-+        "@rolldown/binding-linux-ppc64-gnu": "1.1.1",
-+        "@rolldown/binding-linux-s390x-gnu": "1.1.1",
-+        "@rolldown/binding-linux-x64-gnu": "1.1.1",
-+        "@rolldown/binding-linux-x64-musl": "1.1.1",
-+        "@rolldown/binding-openharmony-arm64": "1.1.1",
-+        "@rolldown/binding-wasm32-wasi": "1.1.1",
-+        "@rolldown/binding-win32-arm64-msvc": "1.1.1",
-+        "@rolldown/binding-win32-x64-msvc": "1.1.1"
++        "@rolldown/binding-android-arm64": "1.1.4",
++        "@rolldown/binding-darwin-arm64": "1.1.4",
++        "@rolldown/binding-darwin-x64": "1.1.4",
++        "@rolldown/binding-freebsd-x64": "1.1.4",
++        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
++        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
++        "@rolldown/binding-linux-arm64-musl": "1.1.4",
++        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
++        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
++        "@rolldown/binding-linux-x64-gnu": "1.1.4",
++        "@rolldown/binding-linux-x64-musl": "1.1.4",
++        "@rolldown/binding-openharmony-arm64": "1.1.4",
++        "@rolldown/binding-wasm32-wasi": "1.1.4",
++        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
++        "@rolldown/binding-win32-x64-msvc": "1.1.4"
 +      }
 +    },
 +    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
@@ -7612,51 +6721,6 @@
 +      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 +      "dev": true,
 +      "license": "MIT"
-+    },
-+    "node_modules/rollup": {
-+      "version": "4.60.4",
-+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
-+      "dev": true,
-+      "license": "MIT",
-+      "dependencies": {
-+        "@types/estree": "1.0.8"
-+      },
-+      "bin": {
-+        "rollup": "dist/bin/rollup"
-+      },
-+      "engines": {
-+        "node": ">=18.0.0",
-+        "npm": ">=8.0.0"
-+      },
-+      "optionalDependencies": {
-+        "@rollup/rollup-android-arm-eabi": "4.60.4",
-+        "@rollup/rollup-android-arm64": "4.60.4",
-+        "@rollup/rollup-darwin-arm64": "4.60.4",
-+        "@rollup/rollup-darwin-x64": "4.60.4",
-+        "@rollup/rollup-freebsd-arm64": "4.60.4",
-+        "@rollup/rollup-freebsd-x64": "4.60.4",
-+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-+        "@rollup/rollup-linux-x64-musl": "4.60.4",
-+        "@rollup/rollup-openbsd-x64": "4.60.4",
-+        "@rollup/rollup-openharmony-arm64": "4.60.4",
-+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
-+        "fsevents": "~2.3.2"
-+      }
 +    },
 +    "node_modules/safe-buffer": {
 +      "version": "5.2.1",
@@ -7696,12 +6760,6 @@
 +      "engines": {
 +        "node": ">=10"
 +      }
-+    },
-+    "node_modules/set-cookie-parser": {
-+      "version": "2.7.2",
-+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-+      "license": "MIT"
 +    },
 +    "node_modules/shebang-command": {
 +      "version": "2.0.0",
@@ -7980,9 +7038,9 @@
 +      }
 +    },
 +    "node_modules/tailwindcss": {
-+      "version": "4.3.0",
-+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
++      "version": "4.3.2",
++      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
++      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
 +      "license": "MIT"
 +    },
 +    "node_modules/tailwindcss-animate": {
@@ -8042,9 +7100,9 @@
 +      }
 +    },
 +    "node_modules/tinyglobby": {
-+      "version": "0.2.16",
-+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
++      "version": "0.2.17",
++      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
++      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -8312,18 +7370,17 @@
 +      "license": "MIT"
 +    },
 +    "node_modules/vite": {
-+      "version": "7.3.3",
-+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
++      "version": "8.1.2",
++      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
++      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "esbuild": "^0.27.0",
-+        "fdir": "^6.5.0",
-+        "picomatch": "^4.0.3",
-+        "postcss": "^8.5.6",
-+        "rollup": "^4.43.0",
-+        "tinyglobby": "^0.2.15"
++        "lightningcss": "^1.32.0",
++        "picomatch": "^4.0.4",
++        "postcss": "^8.5.16",
++        "rolldown": "~1.1.3",
++        "tinyglobby": "^0.2.17"
 +      },
 +      "bin": {
 +        "vite": "bin/vite.js"
@@ -8339,9 +7396,10 @@
 +      },
 +      "peerDependencies": {
 +        "@types/node": "^20.19.0 || >=22.12.0",
++        "@vitejs/devtools": "^0.3.0",
++        "esbuild": "^0.27.0 || ^0.28.0",
 +        "jiti": ">=1.21.0",
 +        "less": "^4.0.0",
-+        "lightningcss": "^1.21.0",
 +        "sass": "^1.70.0",
 +        "sass-embedded": "^1.70.0",
 +        "stylus": ">=0.54.8",
@@ -8354,13 +7412,16 @@
 +        "@types/node": {
 +          "optional": true
 +        },
++        "@vitejs/devtools": {
++          "optional": true
++        },
++        "esbuild": {
++          "optional": true
++        },
 +        "jiti": {
 +          "optional": true
 +        },
 +        "less": {
-+          "optional": true
-+        },
-+        "lightningcss": {
 +          "optional": true
 +        },
 +        "sass": {
@@ -8387,19 +7448,19 @@
 +      }
 +    },
 +    "node_modules/vitest": {
-+      "version": "4.1.6",
-+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
++      "version": "4.1.9",
++      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
++      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@vitest/expect": "4.1.6",
-+        "@vitest/mocker": "4.1.6",
-+        "@vitest/pretty-format": "4.1.6",
-+        "@vitest/runner": "4.1.6",
-+        "@vitest/snapshot": "4.1.6",
-+        "@vitest/spy": "4.1.6",
-+        "@vitest/utils": "4.1.6",
++        "@vitest/expect": "4.1.9",
++        "@vitest/mocker": "4.1.9",
++        "@vitest/pretty-format": "4.1.9",
++        "@vitest/runner": "4.1.9",
++        "@vitest/snapshot": "4.1.9",
++        "@vitest/spy": "4.1.9",
++        "@vitest/utils": "4.1.9",
 +        "es-module-lexer": "^2.0.0",
 +        "expect-type": "^1.3.0",
 +        "magic-string": "^0.30.21",
@@ -8427,12 +7488,12 @@
 +        "@edge-runtime/vm": "*",
 +        "@opentelemetry/api": "^1.9.0",
 +        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-+        "@vitest/browser-playwright": "4.1.6",
-+        "@vitest/browser-preview": "4.1.6",
-+        "@vitest/browser-webdriverio": "4.1.6",
-+        "@vitest/coverage-istanbul": "4.1.6",
-+        "@vitest/coverage-v8": "4.1.6",
-+        "@vitest/ui": "4.1.6",
++        "@vitest/browser-playwright": "4.1.9",
++        "@vitest/browser-preview": "4.1.9",
++        "@vitest/browser-webdriverio": "4.1.9",
++        "@vitest/coverage-istanbul": "4.1.9",
++        "@vitest/coverage-v8": "4.1.9",
++        "@vitest/ui": "4.1.9",
 +        "happy-dom": "*",
 +        "jsdom": "*",
 +        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/opensaas-sh/app_diff/package.json.diff
+++ b/opensaas-sh/app_diff/package.json.diff
@@ -27,6 +27,6 @@
      "react-dom": "^19.2.1",
      "react-hook-form": "^7.60.0",
 +    "react-icons": "^5.5.0",
-     "react-router": "^7.12.0",
+     "react-router": "^8.0.1",
      "stripe": "18.1.0",
      "tailwind-merge": "^2.2.1",

--- a/template/app/package.json
+++ b/template/app/package.json
@@ -39,7 +39,7 @@
     "react-apexcharts": "2.1.0",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.60.0",
-    "react-router": "^7.12.0",
+    "react-router": "^8.0.1",
     "stripe": "18.1.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^4.1.18",
@@ -49,14 +49,14 @@
   },
   "devDependencies": {
     "@faker-js/faker": "8.3.1",
-    "@tailwindcss/vite": "^4.1.18",
+    "@tailwindcss/vite": "^4.3.1",
     "@types/express": "^5.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.7",
     "@wasp.sh/spec": "file:.wasp/spec",
     "prisma": "5.19.1",
     "typescript": "6.0.3",
-    "vite": "^7.0.6",
-    "vitest": "^4.0.16"
+    "vite": "^8.1.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/tools/wasp
+++ b/tools/wasp
@@ -5,10 +5,10 @@
 WASP_CLI_MAIN_URL="https://pkg.pr.new/@wasp.sh/wasp-cli@main"
 
 get_latest_published_commit() {
-  curl -fsLI "$WASP_CLI_MAIN_URL" |
-    grep -i '^x-commit-key:' |
-    cut -d: -f4- |
-    tr -d '[:space:]'
+  curl -fsLI "$WASP_CLI_MAIN_URL" \
+    | grep -i '^x-commit-key:' \
+    | cut -d: -f4- \
+    | tr -d '[:space:]'
 }
 
 latest_commit=$(get_latest_published_commit)


### PR DESCRIPTION
Applies the remaining steps from the [0.24 → 0.25 migration guide](https://wasp-docs-on-main.pages.dev/docs/migration-guide).

Already done in #696/#700: `wasp.version` bump to `^0.25.0`, TypeScript 6.0.3, `tsconfig.wasp.json` ES2025 target/lib + `types: ["node"]`, `tsconfig.src.json` `types: ["react", "node"]`.

This PR finishes step 2 (dependency bumps):

- `react-router` `^7.12.0` → `^8.0.1`
- `vite` `^7.0.6` → `^8.1.0`
- `vitest` `^4.0.16` → `^4.1.9`
- `@tailwindcss/vite` `^4.1.18` → `^4.3.1`

Also regenerates `opensaas-sh/app_diff/package-lock.json.diff` (via `wasp install` on the patched app) and updates the `react-router` context line in `package.json.diff`. The lock diff shrinks by ~900 lines because Vite 8's native bundler drops many transitive deps.

Validated with a clean `rm -rf opensaas-sh/app && patch.sh && diff.sh` round-trip: no spurious changes.