### PR TITLE
fix: sanitize roadmap title backticks

### DIFF
--- a/opensaas-sh/app_diff/src/landing-page/components/RoadmapEpicCard.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/RoadmapEpicCard.tsx.diff
@@ -29,7 +29,7 @@
 +      )}
 +    >
 +      <h4 className="text-base font-semibold leading-tight text-gray-900 transition-opacity dark:text-white">
-+        {epic.name}
++        {epic.name.replace(/`/g, "")}
 +      </h4>
 +
 +      <div className="mt-auto pt-1">


### PR DESCRIPTION
## Summary
- remove raw backticks from GitHub roadmap titles before rendering
- prevent title punctuation from appearing misaligned in the landing page

Closes #583

## Validation
- git diff --check