### PR TITLE
docs: clarify email sender is not needed for social-only auth

### DIFF
--- a/opensaas-sh/blog/src/content/docs/guides/authentication.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authentication.md
@@ -92,3 +92,9 @@ To create a GitHub OAuth app and get your GitHub API keys, follow the instructio
 To create a Discord OAuth app and get your Discord API keys, follow the instructions in [Wasp's Discord Auth docs](https://wasp.sh/docs/auth/social-auth/discord#3-creating-a-discord-app)
 
 Again, Wasp will take care of the rest and update your AuthUI components accordingly.
+
+:::tip[Social auth doesn't require an email sender]
+An "email sender" provider is only needed by the `email` auth method. If you want to use just social auth (Google, GitHub, and/or Discord), you can remove the `email` method from your auth config and you don't have to set up an email provider for authentication.
+
+Keep in mind that Open SaaS also uses `emailSender` outside of auth (e.g. the payment webhook emails users when their subscription is cancelled), so you'll still want a production-ready provider if you keep that code.
+:::


### PR DESCRIPTION
## Description

Fixes #150

The docs currently read as if an "email sender" provider is always required, even for users who only want social auth. This adds a short note to the "Google, GitHub, & Discord Auth" section of the authentication guide making it explicit that:

- an email sender is only needed by the `email` auth method, so if you only use Google/GitHub/Discord you can remove the `email` method and skip setting up an email provider for authentication
- Open SaaS does still use `emailSender` outside of auth (the payment webhook emails users when their subscription is cancelled), so a production-ready provider is still needed if that code is kept

Happy to reword or move the note somewhere else if you'd prefer it in the guided tour / email sending guide as well.

## Contributor Checklist

- [ ] **Update e2e tests**: not applicable, docs-only change.
- [ ] **Update demo app**: not applicable, docs-only change.
- [x] **Update docs**: this PR only changes `opensaas-sh/blog/src/content/docs/guides/authentication.md`.
