### PR TITLE
fix(file-upload): show loading state during AWS uploads

### DIFF
--- a/template/app/src/file-upload/FileUploadPage.tsx
+++ b/template/app/src/file-upload/FileUploadPage.tsx
@@ -27,6 +27,7 @@ import { Progress } from "../client/components/ui/progress";
 import { toast } from "../client/hooks/use-toast";
 import { cn } from "../client/utils";
 import { uploadFileWithProgress, validateFile } from "./fileUploading";
+import { getUploadButtonLabel } from "./uploadUi";
 import { ALLOWED_FILE_TYPES } from "./validation";
 
 export function FileUploadPage() {
@@ -211,9 +212,10 @@ export function FileUploadPage() {
                     {isUploading ? (
                       <>
                         <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
-                        {uploadProgressPercent > 0
-                          ? `Uploading ${uploadProgressPercent}%`
-                          : "Uploading..."}
+                        {getUploadButtonLabel(
+                          isUploading,
+                          uploadProgressPercent,
+                        )}
                       </>
                     ) : (
                       "Upload"

--- a/template/app/src/file-upload/FileUploadPage.tsx
+++ b/template/app/src/file-upload/FileUploadPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "wasp/client/operations";
 import type { File } from "wasp/entities";
 
-import { Download, Trash } from "lucide-react";
+import { Download, LoaderCircle, Trash } from "lucide-react";
 import { Alert, AlertDescription } from "../client/components/ui/alert";
 import { Button } from "../client/components/ui/button";
 import { Card, CardContent, CardTitle } from "../client/components/ui/card";
@@ -32,6 +32,7 @@ import { ALLOWED_FILE_TYPES } from "./validation";
 export function FileUploadPage() {
   const [fileKeyForS3, setFileKeyForS3] = useState<File["s3Key"]>("");
   const [uploadProgressPercent, setUploadProgressPercent] = useState<number>(0);
+  const [isUploading, setIsUploading] = useState(false);
   const [fileToDelete, setFileToDelete] = useState<Pick<
     File,
     "id" | "s3Key" | "name"
@@ -103,6 +104,7 @@ export function FileUploadPage() {
       }
 
       const file = validateFile(formDataFileUpload);
+      setIsUploading(true);
 
       const { s3UploadUrl, s3UploadFields, s3Key } = await createFileUploadUrl({
         fileType: file.type,
@@ -138,6 +140,7 @@ export function FileUploadPage() {
         variant: "destructive",
       });
     } finally {
+      setIsUploading(false);
       setUploadProgressPercent(0);
     }
   };
@@ -202,14 +205,21 @@ export function FileUploadPage() {
                 <div className="space-y-2">
                   <Button
                     type="submit"
-                    disabled={uploadProgressPercent > 0}
+                    disabled={isUploading}
                     className="w-full"
                   >
-                    {uploadProgressPercent > 0
-                      ? `Uploading ${uploadProgressPercent}%`
-                      : "Upload"}
+                    {isUploading ? (
+                      <>
+                        <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+                        {uploadProgressPercent > 0
+                          ? `Uploading ${uploadProgressPercent}%`
+                          : "Uploading..."}
+                      </>
+                    ) : (
+                      "Upload"
+                    )}
                   </Button>
-                  {uploadProgressPercent > 0 && (
+                  {isUploading && (
                     <Progress
                       value={uploadProgressPercent}
                       className="w-full"

--- a/template/app/src/file-upload/uploadUi.test.ts
+++ b/template/app/src/file-upload/uploadUi.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getUploadButtonLabel } from "./uploadUi";
+
+describe("getUploadButtonLabel", () => {
+  it("shows immediate feedback before upload progress is reported", () => {
+    expect(getUploadButtonLabel(true, 0)).toBe("Uploading...");
+  });
+
+  it("shows progress while uploading", () => {
+    expect(getUploadButtonLabel(true, 42)).toBe("Uploading 42%");
+  });
+
+  it("shows the idle label when no upload is active", () => {
+    expect(getUploadButtonLabel(false, 0)).toBe("Upload");
+  });
+});

--- a/template/app/src/file-upload/uploadUi.ts
+++ b/template/app/src/file-upload/uploadUi.ts
@@ -1,0 +1,12 @@
+export function getUploadButtonLabel(
+  isUploading: boolean,
+  uploadProgressPercent: number,
+) {
+  if (!isUploading) {
+    return "Upload";
+  }
+
+  return uploadProgressPercent > 0
+    ? `Uploading ${uploadProgressPercent}%`
+    : "Uploading...";
+}


### PR DESCRIPTION
## Summary

Fixes #709.

The AWS file upload button had no feedback until the first upload-progress callback arrived. This made the upload appear idle during request initialization.

## Changes

- Add an explicit `isUploading` state for the complete upload lifecycle.
- Show a spinning loader and `Uploading...` immediately, then include the percentage when progress is available.
- Keep the button disabled during the full request and restore the idle state on success or failure.
- Add focused regression coverage for idle, initial-upload, and progress states.

## Compatibility

No API, S3, database, or persistence changes. Existing progress behavior is preserved.

## Verification

- `npx --yes vitest run D:\project\tscodex\github_pr\patch-work\uploadUi.test.ts` — 3 tests passed.
- `npx --yes prettier --check D:\project\tscodex\github_pr\patch-work\FileUploadPage.tsx D:\project\tscodex\github_pr\patch-work\uploadUi.ts D:\project\tscodex\github_pr\patch-work\uploadUi.test.ts` — passed.
- Full project lint, type-check, build, and E2E were not run because a complete repository clone repeatedly failed with GitHub transport disconnects; the focused self-contained test does not require AWS or Docker.