### PR TITLE
feat: opt-in keyless i18n of the landing page and nav bar, with a language selector

### DIFF
--- a/opensaas-sh/app_diff/package.json.diff
+++ b/opensaas-sh/app_diff/package.json.diff
@@ -22,7 +22,7 @@
      "@radix-ui/react-accordion": "^1.2.11",
      "@radix-ui/react-avatar": "^1.1.10",
      "@radix-ui/react-checkbox": "^1.3.2",
-@@ -39,6 +44,7 @@
+@@ -40,6 +45,7 @@
      "react-apexcharts": "2.1.0",
      "react-dom": "^19.2.1",
      "react-hook-form": "^7.60.0",

--- a/opensaas-sh/app_diff/src/client/App.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/App.tsx.diff
@@ -6,7 +6,7 @@
  import { Outlet, useLocation } from "react-router";
  import { routes } from "wasp/client/router";
  import { Toaster } from "../client/components/ui/toaster";
-@@ -17,10 +17,7 @@
+@@ -18,10 +18,7 @@
  export function App() {
    const location = useLocation();
    const isMarketingPage = useMemo(() => {
@@ -18,9 +18,9 @@
    }, [location]);
  
    const navigationItems = isMarketingPage
-@@ -38,14 +35,33 @@
-     return location.pathname.startsWith(routes.AdminRoute.to);
-   }, [location]);
+@@ -45,14 +42,33 @@
+     initI18nKeyless();
+   }, []);
  
 +  const resizeObserverRef = useRef<ResizeObserver | null>(null);
 +

--- a/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
+++ b/opensaas-sh/app_diff/src/client/components/NavBar/NavBar.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/client/components/NavBar/NavBar.tsx
 +++ opensaas-sh/app/src/client/components/NavBar/NavBar.tsx
-@@ -3,6 +3,7 @@
+@@ -4,6 +4,7 @@
  import { Link as ReactRouterLink } from "react-router";
  import { useAuth } from "wasp/client/auth";
  import { Link as WaspRouterLink, routes } from "wasp/client/router";
@@ -8,15 +8,15 @@
  import {
    Sheet,
    SheetContent,
-@@ -17,6 +18,7 @@
- import logo from "../../static/logo.svg";
+@@ -19,6 +20,7 @@
  import { cn } from "../../utils";
  import { DarkModeSwitcher } from "../DarkModeSwitcher";
+ import { LanguageSelector } from "../LanguageSelector";
 +import { RepoInfo } from "../RepoInfo";
  import { Announcement } from "./Announcement";
  
  export interface NavigationItem {
-@@ -51,7 +53,7 @@
+@@ -53,7 +55,7 @@
        <header
          className={cn(
            "sticky top-0 z-50 transition-all duration-300",
@@ -25,7 +25,7 @@
          )}
        >
          <div
-@@ -66,7 +68,7 @@
+@@ -68,7 +70,7 @@
              className={cn(
                "flex items-center justify-between transition-all duration-300",
                {
@@ -34,7 +34,7 @@
                  "p-6 lg:px-8": !isScrolled,
                },
              )}
-@@ -87,7 +89,7 @@
+@@ -89,7 +91,7 @@
                      },
                    )}
                  >
@@ -43,13 +43,17 @@
                  </span>
                </WaspRouterLink>
  
-@@ -113,7 +115,12 @@
+@@ -115,8 +117,15 @@
    return (
      <div className="hidden items-center justify-end gap-3 lg:flex lg:flex-1">
        <ul className="flex items-center justify-center gap-2 sm:gap-4">
+-        <LanguageSelector />
 -        <DarkModeSwitcher />
 +        <li>
 +          <RepoInfo />
++        </li>
++        <li>
++          <LanguageSelector />
 +        </li>
 +        <li>
 +          <DarkModeSwitcher />
@@ -57,21 +61,21 @@
        </ul>
        {isUserLoading ? null : !user ? (
          <WaspRouterLink
-@@ -126,10 +133,11 @@
+@@ -129,10 +138,11 @@
              },
            )}
          >
 -          <div className="text-foreground hover:text-primary flex items-center transition-colors duration-300 ease-in-out">
 +          <div className="text-foreground hover:text-primary flex items-center gap-1 transition-colors duration-300 ease-in-out">
 +            <span>Demo App</span>
-             Log in{" "}
+             <T>Log in</T>{" "}
              <LogIn
 -              size={isScrolled ? "1rem" : "1.1rem"}
 +              size="1rem"
                className={cn("transition-all duration-300", {
                  "ml-1 mt-[0.1rem]": !isScrolled,
                  "ml-1": isScrolled,
-@@ -180,7 +188,7 @@
+@@ -185,7 +195,7 @@
            <SheetHeader>
              <SheetTitle className="flex items-center">
                <WaspRouterLink to={routes.LandingPageRoute.to}>
@@ -80,12 +84,12 @@
                  <NavLogo isScrolled={false} />
                </WaspRouterLink>
              </SheetTitle>
-@@ -193,9 +201,9 @@
+@@ -198,9 +208,9 @@
                <div className="py-6">
                  {isUserLoading ? null : !user ? (
                    <WaspRouterLink to={routes.LoginRoute.to}>
 -                    <div className="text-foreground hover:text-primary flex items-center justify-end transition-colors duration-300 ease-in-out">
--                      Log in <LogIn size="1.1rem" className="ml-1" />
+-                      <T>Log in</T> <LogIn size="1.1rem" className="ml-1" />
 -                    </div>
 +                    <Button variant="outline">
 +                      <span>Demo App</span> <LogIn className="ml-1" />
@@ -93,14 +97,20 @@
                    </WaspRouterLink>
                  ) : (
                    <ul className="space-y-2">
-@@ -207,7 +215,14 @@
+@@ -211,9 +221,18 @@
+                   </ul>
                  )}
                </div>
-               <div className="py-6">
+-              <div className="flex items-center justify-between py-6">
 -                <DarkModeSwitcher />
+-                <LanguageSelector />
++              <div className="py-6">
 +                <ul className="flex items-center justify-between gap-4">
 +                  <li>
 +                    <DarkModeSwitcher />
++                  </li>
++                  <li>
++                    <LanguageSelector />
 +                  </li>
 +                  <li>
 +                    <RepoInfo />
@@ -109,7 +119,7 @@
                </div>
              </div>
            </div>
-@@ -252,7 +267,7 @@
+@@ -258,7 +277,7 @@
          "size-7": isScrolled,
        })}
        src={logo}

--- a/opensaas-sh/app_diff/src/landing-page/components/ExamplesCarousel.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/ExamplesCarousel.tsx.diff
@@ -1,11 +1,11 @@
 --- template/app/src/landing-page/components/ExamplesCarousel.tsx
 +++ opensaas-sh/app/src/landing-page/components/ExamplesCarousel.tsx
-@@ -108,7 +108,7 @@
+@@ -109,7 +109,7 @@
        ref={containerRef}
        className="relative left-1/2 my-16 flex w-screen -translate-x-1/2 flex-col items-center"
      >
 -      <h2 className="text-muted-foreground mb-6 text-center font-semibold tracking-wide">
 +      <h2 className="text-muted-foreground mb-6 text-center text-lg font-semibold tracking-wide">
-         Used by:
+         <T>Used by:</T>
        </h2>
        <div className="w-full max-w-full overflow-hidden">

--- a/opensaas-sh/app_diff/src/landing-page/components/FeaturesGrid.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/FeaturesGrid.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/landing-page/components/FeaturesGrid.tsx
 +++ opensaas-sh/app/src/landing-page/components/FeaturesGrid.tsx
-@@ -9,13 +9,15 @@
+@@ -10,13 +10,15 @@
  import { Feature } from "./Features";
  import { SectionTitle } from "./SectionTitle";
  
@@ -17,7 +17,7 @@
  }
  
  interface FeaturesGridProps {
-@@ -59,7 +61,8 @@
+@@ -60,7 +62,8 @@
    direction = "col",
    align = "center",
    size = "medium",
@@ -27,7 +27,7 @@
  }: GridFeature) {
    const gridFeatureSizeToClasses: Record<GridFeature["size"], string> = {
      small: "col-span-1",
-@@ -77,60 +80,98 @@
+@@ -78,62 +81,98 @@
      "col-reverse": "flex-col-reverse",
    };
  
@@ -80,7 +80,7 @@
 +                  direction === "col-reverse" ? "order-1" : "order-2",
 +                )}
 +              >
-+                {name}
++                <T>{name}</T>
 +              </CardTitle>
 +            )}
 +            <CardDescription
@@ -90,7 +90,7 @@
 +                direction === "col-reverse" ? "order-1" : "order-2",
 +              )}
 +            >
-+              {description}
++              <T>{description}</T>
 +            </CardDescription>
            </div>
          ) : (
@@ -124,12 +124,14 @@
 +                align === "center" ? "text-center" : "text-left",
 +              )}
              >
-               {name}
+               <T>{name}</T>
              </CardTitle>
            </div>
          )}
 -        {fullWidthIcon && (icon || emoji) && (
--          <CardTitle className="mb-2 text-center">{name}</CardTitle>
+-          <CardTitle className="mb-2 text-center">
+-            <T>{name}</T>
+-          </CardTitle>
 +        {!fullWidthIcon && (
 +          <CardDescription
 +            className={cn(
@@ -139,7 +141,7 @@
 +                : "text-left",
 +            )}
 +          >
-+            {description}
++            <T>{description}</T>
 +          </CardDescription>
          )}
 -        <CardDescription
@@ -150,12 +152,12 @@
 -              : "text-left",
 -          )}
 -        >
--          {description}
+-          <T>{description}</T>
 -        </CardDescription>
        </CardContent>
      </Card>
    );
-@@ -141,7 +182,7 @@
+@@ -144,7 +183,7 @@
          href={href}
          target="_blank"
          rel="noopener noreferrer"

--- a/opensaas-sh/app_diff/src/landing-page/components/HighlightedFeature.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/HighlightedFeature.tsx.diff
@@ -1,6 +1,6 @@
 --- template/app/src/landing-page/components/HighlightedFeature.tsx
 +++ opensaas-sh/app/src/landing-page/components/HighlightedFeature.tsx
-@@ -1,11 +1,14 @@
+@@ -2,11 +2,14 @@
  import { cn } from "../../client/utils";
  
  interface FeatureProps {
@@ -15,7 +15,7 @@
  }
  
  /**
-@@ -13,11 +16,14 @@
+@@ -14,11 +17,14 @@
   * Shows text description on one side, and whatever component you want to show on the other side to demonstrate the functionality.
   */
  export function HighlightedFeature({
@@ -30,7 +30,7 @@
  }: FeatureProps) {
    const tiltToClass: Record<Required<FeatureProps>["tilt"], string> = {
      left: "rotate-1",
-@@ -26,13 +32,16 @@
+@@ -27,15 +33,18 @@
  
    return (
      <div
@@ -42,14 +42,18 @@
        )}
      >
        <div className="flex-1 flex-col">
--        <h2 className="mb-2 text-4xl font-bold">{name}</h2>
+-        <h2 className="mb-2 text-4xl font-bold">
+-          <T>{name}</T>
+-        </h2>
 +        <a href={url} target="_blank" rel="noopener noreferrer">
-+          <h2 className="mb-2 text-4xl font-bold">{name}</h2>
++          <h2 className="mb-2 text-4xl font-bold">
++            <T>{name}</T>
++          </h2>
 +        </a>
          {typeof description === "string" ? (
-           <p className="text-muted-foreground">{description}</p>
-         ) : (
-@@ -43,6 +52,7 @@
+           <p className="text-muted-foreground">
+             <T>{description}</T>
+@@ -48,6 +57,7 @@
          className={cn(
            "my-10 flex w-full flex-1 items-center justify-center transition-transform duration-300 ease-in-out",
            tilt && tiltToClass[tilt],

--- a/opensaas-sh/app_diff/src/landing-page/components/Testimonials.tsx.diff
+++ b/opensaas-sh/app_diff/src/landing-page/components/Testimonials.tsx.diff
@@ -1,14 +1,17 @@
 --- template/app/src/landing-page/components/Testimonials.tsx
 +++ opensaas-sh/app/src/landing-page/components/Testimonials.tsx
-@@ -1,4 +1,3 @@
+@@ -1,5 +1,4 @@
+-import { T, useTranslation } from "i18n-keyless-react";
 -import { useState } from "react";
++import { T } from "i18n-keyless-react";
  import {
    Card,
    CardContent,
-@@ -21,18 +20,12 @@
+@@ -22,19 +21,12 @@
  }: {
    testimonials: Testimonial[];
  }) {
+-  const t = useTranslation();
 -  const [isExpanded, setIsExpanded] = useState(false);
 -  const shouldShowExpand = testimonials.length > 5;
 -  const mobileItemsToShow = 3;
@@ -25,7 +28,7 @@
            <div key={idx} className="mb-6 break-inside-avoid">
              <Card className="flex flex-col justify-between">
                <CardContent className="p-6">
-@@ -65,19 +58,6 @@
+@@ -69,23 +61,6 @@
            </div>
          ))}
        </div>
@@ -37,8 +40,12 @@
 -            className="text-primary bg-primary/10 hover:bg-primary/20 rounded-lg px-6 py-3 text-sm font-medium transition-colors duration-200"
 -          >
 -            {isExpanded
--              ? "Show Less"
--              : `Show ${testimonials.length - mobileItemsToShow} More`}
+-              ? t("Show Less")
+-              : t("Show {count} More", {
+-                  replace: {
+-                    "{count}": String(testimonials.length - mobileItemsToShow),
+-                  },
+-                })}
 -          </button>
 -        </div>
 -      )}

--- a/opensaas-sh/blog/astro.config.mjs
+++ b/opensaas-sh/blog/astro.config.mjs
@@ -102,6 +102,10 @@ export default defineConfig({
             { label: "SEO & Performance", link: "/guides/seo-performance/" },
             { label: "Email Sending", link: "/guides/email-sending/" },
             { label: "File Uploading", link: "/guides/file-uploading/" },
+            {
+              label: "Internationalization (i18n)",
+              link: "/guides/internationalization/",
+            },
             { label: "Tests", link: "/guides/tests/" },
             {
               label: "How (Not) to Update Your Open SaaS App",

--- a/opensaas-sh/blog/src/content/docs/guides/internationalization.md
+++ b/opensaas-sh/blog/src/content/docs/guides/internationalization.md
@@ -1,0 +1,90 @@
+---
+title: Internationalization (i18n)
+banner:
+  content: |
+    Have an Open SaaS app in production? <a href="https://e44cy1h4s0q.typeform.com/to/EPJCwsMi">We'll send you some swag! 👕</a>
+---
+
+This guide will show you how to serve your app in other languages than English.
+
+Open SaaS ships with a **keyless** i18n setup, powered by [i18n-keyless](https://i18n-keyless.com). It is **off by default**: until you set an API key, the app is English-only and makes no translation request, so you can ignore this guide if you don't need it.
+
+## How it works
+
+With classic i18n libraries, you replace every string in your code with a key (`t("landing.hero.title")`) and maintain one JSON file per language. With a keyless setup, **the English string is the key**:
+
+```tsx
+import { T } from "i18n-keyless-react";
+
+<Button>
+  <T>Get Started</T>
+</Button>;
+```
+
+The first time a visitor loads the page in a new language, the translation server translates the string once (with an LLM), stores it, and every later visitor gets it from the cache. You review and edit the translations on the server's dashboard instead of in your code.
+
+The landing page and the navigation bar are already wrapped this way, so you can see the pattern in `src/landing-page/` and `src/client/components/NavBar/`.
+
+## Enabling it
+
+1. Get a project API key: sign up at [i18n-keyless.com](https://i18n-keyless.com), or [self-host the server](https://docs.i18n-keyless.com/docs/guides/self-hosting) (one Docker image, your own AI provider).
+2. Add the key to your `.env.client` file:
+
+```sh
+REACT_APP_I18N_KEYLESS_API_KEY=your-public-key
+# Only if you self-host. Omit to use the hosted service.
+REACT_APP_I18N_KEYLESS_API_URL=https://your-instance.example.com
+```
+
+3. Restart `wasp start`.
+
+That's it. The navigation bar now shows a language selector next to the dark mode switch, and visitors get the language of their browser on their first visit. The choice is remembered in `localStorage`.
+
+The public key is meant to be shipped in the client bundle: it can only read translations and ask for new ones for your project.
+
+## Translating your own strings
+
+There are two tools, both exported by `i18n-keyless-react`:
+
+- `<T>` for an element: `<h2><T>Frequently asked questions</T></h2>`
+- `useTranslation()` for a string you hand to something else, like a `placeholder`, an `alt` or a `title`:
+
+```tsx
+import { useTranslation } from "i18n-keyless-react";
+
+export function Hero() {
+  const t = useTranslation();
+  return <img alt={t("App screenshot")} src={screenshot} />;
+}
+```
+
+Placeholders go through `replace`:
+
+```tsx
+t("Show {count} More", { replace: { "{count}": String(count) } });
+```
+
+For an ambiguous short string, give the translator a hint with `context`:
+
+```tsx
+<T context="Navigation menu item">Pricing</T>
+```
+
+The template only translates the marketing pages. The same one-line change applies to any other component: wrap the string in `<T>`, or call `t()`.
+
+## Prerendering
+
+The landing page is [prerendered](https://wasp.sh/docs/advanced/prerendering) at build time, in English. React expects the first render in the browser to match that HTML, so the SDK starts **after hydration** (from an effect in `src/client/App.tsx`), then switches to the visitor's language. Search engines index the English page; visitors see their language a few milliseconds later.
+
+## Configuration
+
+`src/client/i18n-keyless.ts` holds the setup: the primary language (`en`), the supported languages (every language the server can answer for), the browser language detection and the `localStorage` fallback. Edit `SUPPORTED_LANGUAGES` there to offer fewer languages in the selector.
+
+## Removing it
+
+If you don't want i18n at all:
+
+1. Delete `src/client/i18n-keyless.ts`, `src/client/i18n-keyless.test.ts` and `src/client/components/LanguageSelector.tsx`.
+2. Remove the `<LanguageSelector />` and `initI18nKeyless()` calls from `NavBar.tsx` and `App.tsx`.
+3. Replace `<T>text</T>` with `text` and `t("text")` with `"text"` where they appear.
+4. Remove `i18n-keyless-react` from `package.json`.

--- a/template/app/.env.client.example
+++ b/template/app/.env.client.example
@@ -2,3 +2,8 @@
 
 # See https://docs.opensaas.sh/guides/analytics/#google-analytics
 REACT_APP_GOOGLE_ANALYTICS_ID=G-...
+
+# See https://docs.opensaas.sh/guides/internationalization/
+# Leave both unset to keep the app English-only: no translation request is made.
+# REACT_APP_I18N_KEYLESS_API_KEY=...
+# REACT_APP_I18N_KEYLESS_API_URL=https://your-i18n-keyless-instance.example.com

--- a/template/app/package.json
+++ b/template/app/package.json
@@ -30,6 +30,7 @@
     "apexcharts": "5.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "i18n-keyless-react": "3.6.0",
     "ky": "^2.0.0",
     "lucide-react": "^0.525.0",
     "openai": "^6.27.0",

--- a/template/app/src/client/App.tsx
+++ b/template/app/src/client/App.tsx
@@ -9,6 +9,7 @@ import {
   marketingNavigationItems,
 } from "./components/NavBar/constants";
 import { CookieConsentBanner } from "./components/cookie-consent/Banner";
+import { initI18nKeyless } from "./i18n-keyless";
 
 /**
  * use this component to wrap all child components
@@ -37,6 +38,12 @@ export function App() {
   const isAdminDashboard = useMemo(() => {
     return location.pathname.startsWith(routes.AdminRoute.to);
   }, [location]);
+
+  // After hydration: the prerendered landing page and the first client render
+  // are both English, then the visitor's language is applied.
+  useEffect(() => {
+    initI18nKeyless();
+  }, []);
 
   useEffect(() => {
     if (location.hash) {

--- a/template/app/src/client/components/LanguageSelector.tsx
+++ b/template/app/src/client/components/LanguageSelector.tsx
@@ -1,0 +1,63 @@
+import {
+  setCurrentLanguage,
+  useCurrentLanguage,
+  useI18nKeyless,
+  useTranslation,
+  type Lang,
+} from "i18n-keyless-react";
+import { Languages } from "lucide-react";
+import { useMemo } from "react";
+import {
+  languageDisplayName,
+  PRIMARY_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+} from "../i18n-keyless";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+
+/**
+ * Lets the visitor pick the UI language. Renders nothing until i18n is
+ * enabled with `REACT_APP_I18N_KEYLESS_API_KEY` (see `src/client/i18n-keyless.ts`).
+ */
+export function LanguageSelector() {
+  const isEnabled = useI18nKeyless((state) => Boolean(state.config.API_KEY));
+  const currentLanguage = useCurrentLanguage() ?? PRIMARY_LANGUAGE;
+  const t = useTranslation();
+
+  const languages = useMemo(() => {
+    const collator = new Intl.Collator();
+    return SUPPORTED_LANGUAGES.map((lang) => ({
+      lang,
+      name: languageDisplayName(lang),
+    })).sort((a, b) => collator.compare(a.name, b.name));
+  }, []);
+
+  if (!isEnabled) return null;
+
+  return (
+    <Select
+      value={currentLanguage}
+      onValueChange={(value) => setCurrentLanguage(value as Lang)}
+    >
+      <SelectTrigger
+        aria-label={t("Language")}
+        className="h-8 w-auto gap-1 border-none px-2 shadow-none"
+      >
+        <Languages className="size-4" aria-hidden="true" />
+        <SelectValue>{languageDisplayName(currentLanguage)}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {languages.map(({ lang, name }) => (
+          <SelectItem key={lang} value={lang} lang={lang}>
+            {name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/template/app/src/client/components/NavBar/NavBar.tsx
+++ b/template/app/src/client/components/NavBar/NavBar.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import { LogIn, Menu } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { Link as ReactRouterLink } from "react-router";
@@ -17,6 +18,7 @@ import { useIsLandingPage } from "../../hooks/useIsLandingPage";
 import logo from "../../static/logo.svg";
 import { cn } from "../../utils";
 import { DarkModeSwitcher } from "../DarkModeSwitcher";
+import { LanguageSelector } from "../LanguageSelector";
 import { Announcement } from "./Announcement";
 
 export interface NavigationItem {
@@ -113,6 +115,7 @@ function NavBarDesktopUserDropdown({ isScrolled }: { isScrolled: boolean }) {
   return (
     <div className="hidden items-center justify-end gap-3 lg:flex lg:flex-1">
       <ul className="flex items-center justify-center gap-2 sm:gap-4">
+        <LanguageSelector />
         <DarkModeSwitcher />
       </ul>
       {isUserLoading ? null : !user ? (
@@ -127,7 +130,7 @@ function NavBarDesktopUserDropdown({ isScrolled }: { isScrolled: boolean }) {
           )}
         >
           <div className="text-foreground hover:text-primary flex items-center transition-colors duration-300 ease-in-out">
-            Log in{" "}
+            <T>Log in</T>{" "}
             <LogIn
               size={isScrolled ? "1rem" : "1.1rem"}
               className={cn("transition-all duration-300", {
@@ -166,7 +169,9 @@ function NavBarMobileMenu({
               "text-muted-foreground hover:text-muted hover:bg-accent inline-flex items-center justify-center rounded-md transition-colors",
             )}
           >
-            <span className="sr-only">Open main menu</span>
+            <span className="sr-only">
+              <T>Open main menu</T>
+            </span>
             <Menu
               className={cn("transition-all duration-300", {
                 "size-8 p-1": !isScrolled,
@@ -194,7 +199,7 @@ function NavBarMobileMenu({
                 {isUserLoading ? null : !user ? (
                   <WaspRouterLink to={routes.LoginRoute.to}>
                     <div className="text-foreground hover:text-primary flex items-center justify-end transition-colors duration-300 ease-in-out">
-                      Log in <LogIn size="1.1rem" className="ml-1" />
+                      <T>Log in</T> <LogIn size="1.1rem" className="ml-1" />
                     </div>
                   </WaspRouterLink>
                 ) : (
@@ -206,8 +211,9 @@ function NavBarMobileMenu({
                   </ul>
                 )}
               </div>
-              <div className="py-6">
+              <div className="flex items-center justify-between py-6">
                 <DarkModeSwitcher />
+                <LanguageSelector />
               </div>
             </div>
           </div>
@@ -237,7 +243,7 @@ function renderNavigationItems(
           onClick={setMobileMenuOpen && (() => setMobileMenuOpen(false))}
           target={item.to.startsWith("http") ? "_blank" : undefined}
         >
-          {item.name}
+          <T>{item.name}</T>
         </ReactRouterLink>
       </li>
     );

--- a/template/app/src/client/i18n-keyless.test.ts
+++ b/template/app/src/client/i18n-keyless.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  detectBrowserLanguage,
+  languageDisplayName,
+  resolveStorage,
+  type KeyValueStorage,
+} from "./i18n-keyless";
+
+describe("detectBrowserLanguage", () => {
+  it("picks the first supported browser language, most preferred first", () => {
+    expect(detectBrowserLanguage(["de-AT", "en-US"])).toBe("de");
+  });
+
+  it("maps regional Chinese tags to the script the server supports", () => {
+    expect(detectBrowserLanguage(["zh-CN"])).toBe("zh-Hans");
+    expect(detectBrowserLanguage(["zh-TW"])).toBe("zh-Hant");
+  });
+
+  it("falls back to English for unknown tags and an empty list", () => {
+    expect(detectBrowserLanguage(["tlh"])).toBe("en");
+    expect(detectBrowserLanguage([])).toBe("en");
+  });
+});
+
+describe("languageDisplayName", () => {
+  it("names a language in that language", () => {
+    expect(languageDisplayName("de")).toBe("Deutsch");
+    expect(languageDisplayName("fr")).toBe("français");
+  });
+});
+
+describe("resolveStorage", () => {
+  function fakeStorage(overrides: Partial<KeyValueStorage> = {}) {
+    return {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      ...overrides,
+    } as unknown as KeyValueStorage;
+  }
+
+  it("returns the browser storage when it is usable", () => {
+    const storage = fakeStorage();
+    expect(resolveStorage(() => storage)).toBe(storage);
+  });
+
+  it("falls back to memory when reading the property throws", () => {
+    const storage = resolveStorage(() => {
+      throw new Error("SecurityError");
+    });
+    expect(storage).not.toBeNull();
+    storage.setItem("k", "v");
+    expect(storage.getItem("k")).toBe("v");
+  });
+
+  it("falls back to memory when the storage throws on first use", () => {
+    const storage = resolveStorage(() =>
+      fakeStorage({
+        getItem: vi.fn(() => {
+          throw new Error("QuotaExceededError");
+        }),
+      }),
+    );
+    storage.setItem("k", "v");
+    expect(storage.getItem("k")).toBe("v");
+  });
+
+  it("falls back to memory when there is no storage at all", () => {
+    const storage = resolveStorage(() => undefined);
+    storage.setItem("k", "v");
+    expect(storage.getItem("k")).toBe("v");
+  });
+});

--- a/template/app/src/client/i18n-keyless.ts
+++ b/template/app/src/client/i18n-keyless.ts
@@ -1,0 +1,126 @@
+import {
+  AVAILABLE_LANGS,
+  createMemoryStorage,
+  init,
+  resolveLang,
+  type I18nConfig,
+  type Lang,
+} from "i18n-keyless-react";
+
+/**
+ * Keyless internationalization (i18n) of the UI.
+ *
+ * The English string in the JSX is the key: `<T>Get Started</T>`. There is no
+ * locale file and no key name to invent. The first time a string is rendered
+ * in a new language, the translation server translates it once (with an LLM),
+ * stores it, and every later visitor gets it from the cache. You review and
+ * fix translations on the server's dashboard, not in JSON files.
+ *
+ * It is opt-in, configured with two client env vars (see `.env.client.example`):
+ *
+ *   REACT_APP_I18N_KEYLESS_API_KEY  the project's public key (enables i18n)
+ *   REACT_APP_I18N_KEYLESS_API_URL  your self-hosted server; omit for the hosted one
+ *
+ * Without a key the app stays English and makes no network request: `<T>`
+ * renders its child string as-is and the language selector is not rendered.
+ *
+ * Docs: https://docs.opensaas.sh/guides/internationalization/
+ */
+
+export const PRIMARY_LANGUAGE: Lang = "en";
+
+/** Every language the translation server can answer for. */
+export const SUPPORTED_LANGUAGES: readonly Lang[] = AVAILABLE_LANGS;
+
+/**
+ * Picks the first browser language we support, most preferred first.
+ * `zh-CN` resolves to `zh-Hans`, `de-AT` to `de`, an unknown tag to English.
+ */
+export function detectBrowserLanguage(preferred: readonly string[]): Lang {
+  for (const tag of preferred) {
+    const lang = resolveLang(tag, { supported: SUPPORTED_LANGUAGES });
+    if (lang) return lang;
+  }
+  return PRIMARY_LANGUAGE;
+}
+
+/** Native display name of a language, in that language ("Deutsch", "ไทย"). */
+export function languageDisplayName(lang: Lang): string {
+  try {
+    return new Intl.DisplayNames([lang], { type: "language" }).of(lang) ?? lang;
+  } catch {
+    return lang;
+  }
+}
+
+type SdkStorage = NonNullable<I18nConfig["storage"]>;
+/** A storage adapter with the three methods the SDK reads and writes through. */
+export type KeyValueStorage = SdkStorage &
+  Required<Pick<SdkStorage, "getItem" | "setItem" | "removeItem">>;
+
+/**
+ * The persistent cache for translations and the chosen language. A browser
+ * can deny `localStorage` (privacy mode, blocked site data): reading the
+ * property itself throws. In that case the SDK runs on an in-memory store,
+ * so the language choice lasts for the session and nothing aborts startup.
+ */
+export function resolveStorage(
+  read: () => KeyValueStorage | undefined,
+): KeyValueStorage {
+  try {
+    const storage = read();
+    if (!storage) return createMemoryStorage() as KeyValueStorage;
+    // Some browsers expose the object and throw on first use.
+    storage.getItem("i18n-keyless:probe");
+    return storage;
+  } catch {
+    return createMemoryStorage() as KeyValueStorage;
+  }
+}
+
+/**
+ * Starts the SDK in the browser. Call it once, after hydration.
+ *
+ * The landing page is prerendered at build time (no `window` there), and React
+ * expects the first client render to match that HTML: both stay English. The
+ * stored or browser language is applied right after hydration, which is why
+ * `App` calls this from an effect and not from Wasp's client `setupFn`.
+ */
+export function initI18nKeyless(): void {
+  if (import.meta.env.SSR || typeof window === "undefined") return;
+
+  const apiKey = import.meta.env.REACT_APP_I18N_KEYLESS_API_KEY as
+    | string
+    | undefined;
+  if (!apiKey) return;
+  const apiUrl = import.meta.env.REACT_APP_I18N_KEYLESS_API_URL as
+    | string
+    | undefined;
+
+  try {
+    init({
+      API_KEY: apiKey,
+      ...(apiUrl ? { API_URL: apiUrl } : {}),
+      storage: resolveStorage(() => window.localStorage),
+      languages: {
+        primary: PRIMARY_LANGUAGE,
+        supported: [...SUPPORTED_LANGUAGES],
+        fallback: PRIMARY_LANGUAGE,
+        initWithDefault: detectBrowserLanguage(
+          navigator.languages ?? [navigator.language],
+        ),
+      },
+    }).catch((error: unknown) => {
+      console.warn(
+        "i18n-keyless: translations unavailable, the UI stays in English",
+        error,
+      );
+    });
+  } catch (error) {
+    // Translation is a progressive enhancement: never block the first render.
+    console.warn(
+      "i18n-keyless: initialization failed, the UI stays in English",
+      error,
+    );
+  }
+}

--- a/template/app/src/landing-page/components/ExamplesCarousel.tsx
+++ b/template/app/src/landing-page/components/ExamplesCarousel.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import { Ref, useEffect, useRef, useState } from "react";
 import { Card, CardContent } from "../../client/components/ui/card";
 
@@ -109,7 +110,7 @@ export function ExamplesCarousel({ examples }: { examples: ExampleApp[] }) {
       className="relative left-1/2 my-16 flex w-screen -translate-x-1/2 flex-col items-center"
     >
       <h2 className="text-muted-foreground mb-6 text-center font-semibold tracking-wide">
-        Used by:
+        <T>Used by:</T>
       </h2>
       <div className="w-full max-w-full overflow-hidden">
         <div
@@ -166,9 +167,11 @@ function ExampleCard({
             className="aspect-video h-auto w-full object-cover object-top"
           />
           <div className="p-4">
-            <p className="font-bold">{example.name}</p>
+            <p className="font-bold">
+              <T>{example.name}</T>
+            </p>
             <p className="text-muted-foreground text-xs">
-              {example.description}
+              <T>{example.description}</T>
             </p>
           </div>
         </CardContent>

--- a/template/app/src/landing-page/components/FAQ.tsx
+++ b/template/app/src/landing-page/components/FAQ.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import {
   Accordion,
   AccordionContent,
@@ -16,7 +17,7 @@ export function FAQ({ faqs }: { faqs: FAQ[] }) {
   return (
     <div className="mx-auto mt-32 max-w-4xl px-6 pb-8 sm:pb-24 sm:pt-12 lg:max-w-7xl lg:px-8 lg:py-32">
       <h2 className="text-foreground mb-12 text-center text-2xl font-bold leading-10 tracking-tight">
-        Frequently asked questions
+        <T>Frequently asked questions</T>
       </h2>
 
       <Accordion type="single" collapsible className="w-full space-y-4">
@@ -27,19 +28,19 @@ export function FAQ({ faqs }: { faqs: FAQ[] }) {
             className="border-border hover:bg-muted/20 rounded-lg border px-6 py-2 transition-all duration-200"
           >
             <AccordionTrigger className="text-foreground hover:text-primary text-left text-base font-semibold leading-7 transition-colors duration-200">
-              {faq.question}
+              <T>{faq.question}</T>
             </AccordionTrigger>
             <AccordionContent className="text-muted-foreground">
               <div className="flex flex-col items-start justify-between gap-4">
                 <p className="text-muted-foreground flex-1 text-base leading-7">
-                  {faq.answer}
+                  <T>{faq.answer}</T>
                 </p>
                 {faq.href && (
                   <a
                     href={faq.href}
                     className="text-primary hover:text-primary/80 shrink-0 whitespace-nowrap text-base font-medium leading-7 transition-colors duration-200"
                   >
-                    Learn more →
+                    <T>Learn more</T> →
                   </a>
                 )}
               </div>

--- a/template/app/src/landing-page/components/Features.tsx
+++ b/template/app/src/landing-page/components/Features.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import { SectionTitle } from "./SectionTitle";
 
 export interface Feature {
@@ -13,7 +14,7 @@ export function Features({ features }: { features: Feature[] }) {
       <SectionTitle
         title={
           <p className="text-foreground mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
-            The <span className="text-secondary">Best</span> Features
+            <T>The Best Features</T>
           </p>
         }
         description="Don't work harder. Work smarter."
@@ -26,10 +27,10 @@ export function Features({ features }: { features: Feature[] }) {
                 <div className="border-accent bg-accent/30 absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg border">
                   <div className="text-2xl">{feature.icon}</div>
                 </div>
-                {feature.name}
+                <T>{feature.name}</T>
               </dt>
               <dd className="text-muted-foreground mt-2 text-base leading-7">
-                {feature.description}
+                <T>{feature.description}</T>
               </dd>
             </div>
           ))}

--- a/template/app/src/landing-page/components/FeaturesGrid.tsx
+++ b/template/app/src/landing-page/components/FeaturesGrid.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import React from "react";
 import {
   Card,
@@ -114,12 +115,14 @@ function FeaturesGridItem({
             <CardTitle
               className={cn(align === "center" ? "text-center" : "text-left")}
             >
-              {name}
+              <T>{name}</T>
             </CardTitle>
           </div>
         )}
         {fullWidthIcon && (icon || emoji) && (
-          <CardTitle className="mb-2 text-center">{name}</CardTitle>
+          <CardTitle className="mb-2 text-center">
+            <T>{name}</T>
+          </CardTitle>
         )}
         <CardDescription
           className={cn(
@@ -129,7 +132,7 @@ function FeaturesGridItem({
               : "text-left",
           )}
         >
-          {description}
+          <T>{description}</T>
         </CardDescription>
       </CardContent>
     </Card>

--- a/template/app/src/landing-page/components/Footer.tsx
+++ b/template/app/src/landing-page/components/Footer.tsx
@@ -1,3 +1,5 @@
+import { T } from "i18n-keyless-react";
+
 interface NavigationItem {
   name: string;
   href: string;
@@ -18,12 +20,12 @@ export function Footer({
         className="relative border-t border-gray-900/10 py-24 sm:mt-32 dark:border-gray-200/10"
       >
         <h2 id="footer-heading" className="sr-only">
-          Footer
+          <T>Footer</T>
         </h2>
         <div className="mt-10 flex items-start justify-end gap-20">
           <div>
             <h3 className="text-sm font-semibold leading-6 text-gray-900 dark:text-white">
-              App
+              <T>App</T>
             </h3>
             <ul role="list" className="mt-6 space-y-4">
               {footerNavigation.app.map((item) => (
@@ -32,7 +34,7 @@ export function Footer({
                     href={item.href}
                     className="text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-white"
                   >
-                    {item.name}
+                    <T>{item.name}</T>
                   </a>
                 </li>
               ))}
@@ -40,7 +42,7 @@ export function Footer({
           </div>
           <div>
             <h3 className="text-sm font-semibold leading-6 text-gray-900 dark:text-white">
-              Company
+              <T>Company</T>
             </h3>
             <ul role="list" className="mt-6 space-y-4">
               {footerNavigation.company.map((item) => (
@@ -49,7 +51,7 @@ export function Footer({
                     href={item.href}
                     className="text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-white"
                   >
-                    {item.name}
+                    <T>{item.name}</T>
                   </a>
                 </li>
               ))}

--- a/template/app/src/landing-page/components/Hero.tsx
+++ b/template/app/src/landing-page/components/Hero.tsx
@@ -1,9 +1,12 @@
+import { T, useTranslation } from "i18n-keyless-react";
 import { Link as WaspRouterLink, routes } from "wasp/client/router";
 import { Button } from "../../client/components/ui/button";
 import openSaasBannerDark from "../../client/static/open-saas-banner-dark.svg";
 import openSaasBannerLight from "../../client/static/open-saas-banner-light.svg";
 
 export function Hero() {
+  const t = useTranslation();
+
   return (
     <div className="relative w-full pt-14">
       <TopGradient />
@@ -12,21 +15,23 @@ export function Hero() {
         <div className="max-w-8xl mx-auto px-6 lg:px-8">
           <div className="lg:mb-18 mx-auto max-w-3xl text-center">
             <h1 className="text-foreground text-5xl font-bold sm:text-6xl">
-              Some <span className="italic">cool</span> words about{" "}
-              <span className="text-gradient-primary">your product</span>
+              <T>Some cool words about</T>{" "}
+              <span className="text-gradient-primary">
+                <T>your product</T>
+              </span>
             </h1>
             <p className="text-muted-foreground mx-auto mt-6 max-w-2xl text-lg leading-8">
-              With some more exciting words about your product!
+              <T>With some more exciting words about your product!</T>
             </p>
             <div className="mt-10 flex items-center justify-center gap-x-6">
               <Button size="lg" variant="outline" asChild>
                 <WaspRouterLink to={routes.PricingPageRoute.to}>
-                  Learn More
+                  <T>Learn More</T>
                 </WaspRouterLink>
               </Button>
               <Button size="lg" variant="default" asChild>
                 <WaspRouterLink to={routes.SignupRoute.to}>
-                  Get Started <span aria-hidden="true">→</span>
+                  <T>Get Started</T> <span aria-hidden="true">→</span>
                 </WaspRouterLink>
               </Button>
             </div>
@@ -35,7 +40,7 @@ export function Hero() {
             <div className="m-2 hidden justify-center rounded-xl md:flex lg:-m-4 lg:rounded-2xl lg:p-4">
               <img
                 src={openSaasBannerLight}
-                alt="App screenshot"
+                alt={t("App screenshot")}
                 width={1000}
                 height={530}
                 loading="lazy"
@@ -43,7 +48,7 @@ export function Hero() {
               />
               <img
                 src={openSaasBannerDark}
-                alt="App screenshot"
+                alt={t("App screenshot")}
                 width={1000}
                 height={530}
                 loading="lazy"

--- a/template/app/src/landing-page/components/HighlightedFeature.tsx
+++ b/template/app/src/landing-page/components/HighlightedFeature.tsx
@@ -1,3 +1,4 @@
+import { T } from "i18n-keyless-react";
 import { cn } from "../../client/utils";
 
 interface FeatureProps {
@@ -32,9 +33,13 @@ export function HighlightedFeature({
       )}
     >
       <div className="flex-1 flex-col">
-        <h2 className="mb-2 text-4xl font-bold">{name}</h2>
+        <h2 className="mb-2 text-4xl font-bold">
+          <T>{name}</T>
+        </h2>
         {typeof description === "string" ? (
-          <p className="text-muted-foreground">{description}</p>
+          <p className="text-muted-foreground">
+            <T>{description}</T>
+          </p>
         ) : (
           description
         )}

--- a/template/app/src/landing-page/components/SectionTitle.tsx
+++ b/template/app/src/landing-page/components/SectionTitle.tsx
@@ -1,3 +1,5 @@
+import { T } from "i18n-keyless-react";
+
 export function SectionTitle({
   title,
   description,
@@ -9,7 +11,7 @@ export function SectionTitle({
   const titleElement =
     typeof title === "string" ? (
       <h3 className="text-foreground mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
-        {title}
+        <T>{title}</T>
       </h3>
     ) : (
       title
@@ -17,7 +19,7 @@ export function SectionTitle({
   const descriptionElement =
     typeof description === "string" ? (
       <p className="text-muted-foreground mt-4 text-lg leading-8">
-        {description}
+        <T>{description}</T>
       </p>
     ) : (
       description

--- a/template/app/src/landing-page/components/Testimonials.tsx
+++ b/template/app/src/landing-page/components/Testimonials.tsx
@@ -1,3 +1,4 @@
+import { T, useTranslation } from "i18n-keyless-react";
 import { useState } from "react";
 import {
   Card,
@@ -21,6 +22,7 @@ export function Testimonials({
 }: {
   testimonials: Testimonial[];
 }) {
+  const t = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const shouldShowExpand = testimonials.length > 5;
   const mobileItemsToShow = 3;
@@ -37,7 +39,9 @@ export function Testimonials({
             <Card className="flex flex-col justify-between">
               <CardContent className="p-6">
                 <blockquote className="mb-4 leading-6">
-                  <p className="text-sm italic">{testimonial.quote}</p>
+                  <p className="text-sm italic">
+                    <T>{testimonial.quote}</T>
+                  </p>
                 </blockquote>
               </CardContent>
               <CardFooter className="flex flex-col pt-0">
@@ -56,7 +60,7 @@ export function Testimonials({
                       {testimonial.name}
                     </CardTitle>
                     <CardDescription className="truncate text-xs">
-                      {testimonial.role}
+                      <T>{testimonial.role}</T>
                     </CardDescription>
                   </div>
                 </a>
@@ -73,8 +77,12 @@ export function Testimonials({
             className="text-primary bg-primary/10 hover:bg-primary/20 rounded-lg px-6 py-3 text-sm font-medium transition-colors duration-200"
           >
             {isExpanded
-              ? "Show Less"
-              : `Show ${testimonials.length - mobileItemsToShow} More`}
+              ? t("Show Less")
+              : t("Show {count} More", {
+                  replace: {
+                    "{count}": String(testimonials.length - mobileItemsToShow),
+                  },
+                })}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Description

Refs #23. Follows up on #342 (i18next, stale-closed), with a different approach.

Adds an **opt-in, keyless i18n** setup to the template: the landing page and the navigation bar are translatable into 48 languages, with browser language detection and a language selector next to the dark mode switch. It is **off by default**. Without `REACT_APP_I18N_KEYLESS_API_KEY` the app is English-only and makes no request.

### Why keyless, and why this answers the "optional / bloat" concern in #23

In #23 @Martinsos wrote that i18n might be "an unnecessary complication/bloat" for people who do not need it, "since now every string is handled as a localized one", and asked whether it could be made optional.

With a keyless setup, **the English string is the key**:

```tsx
<Button>
  <T>Get Started</T>
</Button>
```

- No locale files, no key names, nothing to keep in sync. `#342` touched 16 files and shipped a JSON file per language; this PR ships zero.
- Optional by construction: one env var enables it. Unset, `<T>` renders its child string as-is and the selector is not rendered. A user who does not care sees English and can leave the wrapper in place, or remove it (documented in the guide).
- The first visitor in a new language triggers one LLM translation on the server, which is cached and reviewed on a dashboard, not in code.

### What changed

- `template/app/src/client/i18n-keyless.ts` (new): the SDK init, read from `REACT_APP_I18N_KEYLESS_API_KEY` / `REACT_APP_I18N_KEYLESS_API_URL`, browser language detection (`zh-CN` → `zh-Hans`, `de-AT` → `de`, unknown → `en`), native language names through `Intl.DisplayNames`, and a `localStorage` fallback to memory for browsers that deny it. Nothing can throw during startup.
- `template/app/src/client/App.tsx`: starts the SDK **after hydration**. The landing page is prerendered in English at build time; the first client render must match, then the visitor's language is applied. (Using Wasp's `setupFn` would produce a hydration mismatch on the prerendered route.)
- `template/app/src/client/components/LanguageSelector.tsx` (new): built on the existing `ui/select`, renders nothing when i18n is not configured.
- `NavBar.tsx`: nav items, "Log in" and the sr-only label through `<T>`; the selector on desktop and in the mobile sheet.
- Landing page components (`Hero`, `SectionTitle`, `FeaturesGrid`, `Features`, `HighlightedFeature`, `ExamplesCarousel`, `Testimonials`, `FAQ`, `Footer`): visible strings wrapped in `<T>`, attributes through `useTranslation()`. `contentSections.tsx` is untouched: the data stays plain strings, translation happens where they render.
- `template/app/.env.client.example`: the two variables, commented out.
- `template/app/src/client/i18n-keyless.test.ts` (new): language detection, display names, storage fallback (`wasp test client`).
- `template/app/package.json`: `i18n-keyless-react@3.6.0`.
- Docs: new guide `opensaas-sh/blog/src/content/docs/guides/internationalization.md` (enable, use, prerendering note, configure, remove) and its sidebar entry.
- `opensaas-sh/app_diff/`: regenerated with `patch.sh` + `diff.sh`, so the demo app gets the same change.

Out of scope, on purpose: the app pages (demo AI app, account, admin, pricing). The same one-line change applies to each string; this PR keeps the diff reviewable.

### Disclosure

I am the author of i18n-keyless. The translation server is configuration, not a default: without the key the template makes no network request. You can try the PR against the demo instance below, use the hosted service, or run your own instance (one Docker image, your own AI provider, [self-hosting guide](https://docs.i18n-keyless.com/docs/guides/self-hosting)). The SDK is MIT.

### Verification

Automated (from `template/app`):

```bash
wasp compile
wasp test client run
```

From the repo root: `npm run prettier:check`, `npm run lint`, `./opensaas-sh/tools/patch.sh && ./opensaas-sh/tools/diff.sh` (no uncommitted changes).

Manual:

1. Add to `template/app/.env.client`, then `wasp start`:

   ```
   REACT_APP_I18N_KEYLESS_API_KEY=TXgf8PpHp3zxLJcc
   REACT_APP_I18N_KEYLESS_API_URL=https://i18n-keyless.ambroselli.io
   ```

2. A language selector appears in the nav bar. Pick `Deutsch` or `ไทย`: the nav bar, the hero, the features grid, the testimonials, the FAQ and the footer switch. The first switch to a new language can show English for about a second while the server translates; later loads read the cache.
3. Reload: the language persists. Clear `localStorage` and set the browser language to `de-DE`: the app boots in German.
4. Remove the variables and restart: no selector, English, no request.

### Note on `min-release-age`

`template/app/.npmrc` has `min-release-age=7`. `i18n-keyless-react@3.6.0` was published on 2026-09-03, so `wasp install` accepts it from **2026-09-10**. Before that date, install locally with `npm_config_min_release_age=0 wasp install`. I will keep the PR up to date until then.

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [x] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also. — The existing landing page tests still pass unchanged: without a key the strings are identical.
- [x] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [x] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
